### PR TITLE
Added support for Sequences (aka macros)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "keyberon"
 version = "0.1.1"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "Robin Krahl <robin.krahl@ireas.org>"]
 edition = "2018"
-description = "Parse command line argument by defining a struct."
+description = "Pure Rust keyboard firmware."
 documentation = "https://docs.rs/keyberon"
 repository = "https://github.com/TeXitoi/keyberon"
 keywords = ["keyboard", "usb-device", "firmware"]
@@ -12,7 +12,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-either = { version = "1.5", default-features = false }
+either = { version = "1.6", default-features = false }
 generic-array = "0.13"
 embedded-hal = { version = "0.2", features = ["unproven"] }
 usb-device = "0.2.0"

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,6 +1,20 @@
-//! The different actions that can be done.
+//! The different actions that can be executed via any given key.
 
 use crate::key_code::KeyCode;
+
+/// The different types of actions we support for key macros
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SequenceEvent {
+    /// A keypress/keydown
+    Press(KeyCode),
+    /// Key release/keyup
+    Release(KeyCode),
+    /// Combination quick keydown followed by keyrelease
+    Tap(KeyCode),
+    /// Release all (currently) pressed keys
+    ReleaseAll(),
+}
 
 /// The different actions that can be done.
 #[non_exhaustive]
@@ -41,6 +55,13 @@ pub enum Action {
         /// The tap action.
         tap: &'static Action,
     },
+    /// A sequence of KeyEvents
+    Sequence {
+        /// How long to delay between events
+        delay: u16, // NOTE: Currently unused
+        /// The sequence of KeyEvents that will be triggered
+        actions: &'static [SequenceEvent],
+    },
 }
 impl Action {
     /// Gets the layer number if the action is the `Layer` action.
@@ -55,6 +76,7 @@ impl Action {
         match self {
             Action::KeyCode(kc) => core::slice::from_ref(kc).iter().cloned(),
             Action::MultipleKeyCodes(kcs) => kcs.iter().cloned(),
+            // Action::Sequence { delay, actions } => actions.iter().cloned(), // TODO (maybe unnecessary)
             _ => [].iter().cloned(),
         }
     }
@@ -78,8 +100,33 @@ pub const fn d(layer: usize) -> Action {
     Action::DefaultLayer(layer)
 }
 
-/// A shortcut to create a `Action::KeyCode`, useful to create compact
+/// A shortcut to create `Action::MultipleKeyCodes`, useful to create compact
 /// layout.
 pub const fn m(kcs: &'static [KeyCode]) -> Action {
     Action::MultipleKeyCodes(kcs)
+}
+
+/// A shortcut to create `KeyEvent::Tap`, useful to create compact
+/// layout.
+pub const fn tap(kc: KeyCode) -> SequenceEvent {
+    SequenceEvent::Tap(kc)
+}
+
+/// A shortcut to create `KeyEvent::Press`, useful to create compact
+/// layout.
+pub const fn kp(kc: KeyCode) -> SequenceEvent {
+    SequenceEvent::Press(kc)
+}
+
+/// A shortcut to create `KeyEvent::Release`, useful to create compact
+/// layout.
+pub const fn kr(kc: KeyCode) -> SequenceEvent {
+    SequenceEvent::Release(kc)
+}
+
+// NOTE: This doesn't work yet:
+/// A shortcut to create `KeyEvent::Release`, useful to create compact
+/// layout.
+pub const fn ra() -> SequenceEvent {
+    SequenceEvent::ReleaseAll()
 }


### PR DESCRIPTION
Demo: https://youtu.be/M2OXrNP3fgI

Example usage:

```rust
use keyberon::action::{k, l, m, kp, kr, tap, Action, Action::*, SequenceEvent};
use keyberon::key_code::KeyCode::{self, *};

const MACROTEST: Action = Sequence {
    delay: 10,
    actions: &[
        SequenceEvent::Press(LCtrl), SequenceEvent::Press(LShift), SequenceEvent::Press(U), // Long form
        tap(Kb1), tap(F), tap(Kb4), tap(A), tap(F), // Short form
        kr(LCtrl), kr(LShift), kr(U), // Still need to get ReleaseAll() working
    ],
};
```

I couldn't get working `SequenceEvent::ReleaseAll()` (see: https://github.com/riskable/keyberon/blob/master/src/layout.rs#L324) working.  Probably a trivial task for you =)

Also, I'm not sure what the purpose is of that `transform()` method (it's not used anywhere) so I just guessed in my own implementation, haha.  I also didn't implement `Action.key_codes()` for `Action::Sequence` because I'm not sure it's necessary.  I have a little commented out line in place where it'd go.

Overall it wasn't too bad and I learned a ton.  Thanks for the assistance and let me know what I have to change or if it's all bad or whatever =)