### PR TITLE
Fix a panic on rust 1.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.2.0
+
+Breaking changes:
+* Update to generic_array 0.14, that is exposed in matrix. The update
+  should be transparent.
+
 # v0.1.1
 
 *  HidClass::control_xxx: check interface number [#26](https://github.com/TeXitoi/keyberon/pull/26)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 either = { version = "1.6", default-features = false }
-generic-array = "0.13"
+generic-array = "0.14"
 embedded-hal = { version = "0.2", features = ["unproven"] }
 usb-device = "0.2.0"
 heapless = "0.5"

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -68,9 +68,11 @@ impl<C, R> Matrix<C, R> {
         &'a mut R: IntoIterator<Item = &'a mut dyn OutputPin<Error = E>>,
         R: HeterogenousArray,
         R::Len: ArrayLength<GenericArray<bool, C::Len>>,
+        R::Len: heapless::ArrayLength<GenericArray<bool, C::Len>>,
         &'a C: IntoIterator<Item = &'a dyn InputPin<Error = E>>,
         C: HeterogenousArray,
         C::Len: ArrayLength<bool>,
+        C::Len: heapless::ArrayLength<bool>,
     {
         let cols = &self.cols;
         self.rows


### PR DESCRIPTION
rust 1.48 assert that mem::uninitialized is used with types that are valid
for any value, and that's not the case for bool. This cause a panic in the
matrix handling throw generic_array. Upgrading to generic_array 0.14 fixes
the panic as it now uses MaybeUninit.