### PR TITLE
avoid relying on implicit promotion

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -619,9 +619,13 @@ mod test {
 
     #[test]
     fn multiple_actions() {
+        const L1: Action = l(1);
+        const K_SHIFT: Action = k(LShift);
+        const KF: Action = k(F);
+        const KE: Action = k(E);
         static LAYERS: Layers = &[
-            &[&[MultipleActions(&[l(1), k(LShift)]), k(F)]],
-            &[&[Trans, k(E)]],
+            &[&[MultipleActions(&[L1, K_SHIFT]), KF]],
+            &[&[Trans, KE]],
         ];
         let mut layout = Layout::new(LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());


### PR DESCRIPTION
There are plans to [change the rules for implicit promotion](https://github.com/rust-lang/rfcs/pull/3027) such that calls to `const fn` are not implicitly promoted to `'static` lifetime any more. A [crater experiment](https://github.com/rust-lang/rust/pull/80243) showed that only very few crates would be affected by this change, and this is one of them.

This PR adjusts the code to no longer rely on implicit promotion, by explicitly putting the result of the function call into a `const` item. Long-term, there will be the possibility of using [inline const expressions](https://github.com/rust-lang/rust/issues/76001) instead, which will be more ergonomic.