### PR TITLE
Fix typo in keycode name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes:
   example), manage a mouse emulation, or any other ideas you can
   have. As there is a default value for the type parameter, the update
   should be transparent.
+* Typo fix for MediaCoffee enum KeyCode.
 
 # v0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Breaking changes:
   example), manage a mouse emulation, or any other ideas you can
   have. As there is a default value for the type parameter, the update
   should be transparent.
-* Typo fix for MediaCoffee enum KeyCode.
+* Rename MeidaCoffee in MediaCoffee to fix typo.
 
 # v0.1.1
 

--- a/src/key_code.rs
+++ b/src/key_code.rs
@@ -252,7 +252,7 @@ pub enum KeyCode {
     MediaScrollDown,
     MediaEdit,
     MediaSleep,
-    MeidaCoffee,
+    MediaCoffee,
     MediaRefresh,
     MediaCalc, // 0xFB
 }


### PR DESCRIPTION
Fix a simple typo in a media keycode name.