### PR TITLE
Add function to get the underlying leds object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.2.0
 
+* New Keyboard::leds_mut function for getting underlying leds object.
+
 Breaking changes:
 * Update to generic_array 0.14, that is exposed in matrix. The update
   should be transparent.

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -51,6 +51,11 @@ impl<L> Keyboard<L> {
             true
         }
     }
+
+    /// Returns the underlying leds object.
+    pub fn leds_mut(&mut self) -> &mut L {
+        &mut self.leds
+    }
 }
 
 impl<L: Leds> HidDevice for Keyboard<L> {


### PR DESCRIPTION
Can be used when the led controler is shared for both the status led and other
custom actions.