### PR TITLE
Expose the current layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.2.0
 
 * New Keyboard::leds_mut function for getting underlying leds object.
+* Made Layout::current_layer public for getting current active layer.
 
 Breaking changes:
 * Update to generic_array 0.14, that is exposed in matrix. The update

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -393,7 +393,9 @@ impl<T: 'static> Layout<T> {
         }
         CustomEvent::NoEvent
     }
-    fn current_layer(&self) -> usize {
+
+    /// Obtain the index of the current active layer
+    pub fn current_layer(&self) -> usize {
         let mut iter = self.states.iter().filter_map(State::get_layer);
         let mut layer = match iter.next() {
             None => self.default_layer,


### PR DESCRIPTION
Hey!

I'm currently working on getting Keyberon working with the nrf52840 on the makerdiary m60, and I realized that I had no way to query the current active layer.

I wanted this so I could show different LED patterns on the keys (highlighting overlaid keys, like a D-pad), but I couldn't figure out another way to get this info.

Let me know if I missed a preferred way, or if this is too much of an "implementation detail" for the public API.