### PR TITLE
Fix typos and grammtical errors, elide lifetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ The supported features are:
  - Layers when holding a key (aka the fn key). When holding multiple
    layer keys, the numbers add (if you have a layer 1 key and a layer
    2 key, when holding the 2 together, the layer 3 will be active).
- - Transparent key, i.e. when on a alternative layer, the key have the
-   same behavior of the default layer.
+ - Transparent key, i.e. when on an alternative layer, the key will
+   inherit the behavior of the default layer.
  - Change default layer dynamically.
- - Multiple keys send on an single key press. It allows to have keys
-   for complex shortcut, as a key for copy and paste, for alt tab, or
+ - Multiple keys sent on an single key press. It allows to have keys
+   for complex shortcut, for example a key for copy and paste or alt tab, or
    for whatever you want.
- - hold tap: different action depending if the key is holded or
+ - hold tap: different action depending if the key is held or
    tapped. For example, you can have a key acting as layer change when
-   holded, and space when tapped.
+   held, and space when tapped.
    
 
 ## FAQ

--- a/src/action.rs
+++ b/src/action.rs
@@ -38,26 +38,26 @@ where
     /// Transparent, i.e. get the action from the default layer. On
     /// the default layer, it is equivalent to `NoOp`.
     Trans,
-    /// A key code, i.e. the classical key.
+    /// A key code, i.e. a classic key.
     KeyCode(KeyCode),
-    /// Multiple key codes send at the same time, as it you press all
-    /// these keys at the same time.  Useful to send shifted key, or
-    /// complex short cuts as Ctrl+Alt+Del in a single key press.
+    /// Multiple key codes sent at the same time, as if these keys
+    /// were pressed at the same time. Useful to send a shifted key,
+    /// or complex shortcuts like Ctrl+Alt+Del in a single key press.
     MultipleKeyCodes(&'static [KeyCode]),
-    /// Multiple actions send at the same time.
+    /// Multiple actions sent at the same time.
     MultipleActions(&'static [Action<T>]),
-    /// While pressed, change the current layer. That's the classical
+    /// While pressed, change the current layer. That's the classic
     /// Fn key. If several layer actions are active at the same time,
-    /// their number are summed. For example, if you press at the same
+    /// their numbers are summed. For example, if you press at the same
     /// time `Layer(1)` and `Layer(2)`, layer 3 will be active.
     Layer(usize),
     /// Change the default layer.
     DefaultLayer(usize),
-    /// If the key is hold more than `timeout` units of time (usually
+    /// If the key is held more than `timeout` ticks (usually
     /// milliseconds), performs the `hold` action, else performs the
     /// `tap` action.  Mostly used with a modifier for the hold action
-    /// and a classical key on the tap action. Any action can be
-    /// performed, but using a `HoldTap` in an `HoldTap` is not
+    /// and a normal key on the tap action. Any action can be
+    /// performed, but using a `HoldTap` in a `HoldTap` is not
     /// specified (but guaranteed to not crash).
     ///
     /// Different behaviors can be configured using the config field,
@@ -76,14 +76,14 @@ where
         config: HoldTapConfig,
         /// Configuration of the tap and hold holds the tap action.
         ///
-        /// If you press, release the key in such a configuration that
-        /// the tap behavior is done, and then press again the key in
-        /// less than `tap_hold_interval` ticks, the tap action will
-        /// be used. This allow to have a tap action holded by
-        /// "tap+hold" the key, allowing the computer to auto repeat
-        /// the tap behavior.
+        /// If you press and release the key in such a way that the tap
+        /// action is performed, and then press it again in less than
+        /// `tap_hold_interval` ticks, the tap action will
+        /// be held. This allows the tap action to be held by
+        /// pressing, releasing and holding the key, allowing the computer
+        //// to auto repeat the tap behavior.
         ///
-        /// To desactivate the functionnality, set this to 0.
+        /// To deactivate the functionality, set this to 0.
         ///
         /// Not implemented yet, to not have behavior change with an
         /// update, set this to 0.
@@ -106,7 +106,7 @@ impl<T> Action<T> {
         }
     }
     /// Returns an iterator on the `KeyCode` corresponding to the action.
-    pub fn key_codes<'a>(&'a self) -> impl Iterator<Item = KeyCode> + 'a {
+    pub fn key_codes(&self) -> impl Iterator<Item = KeyCode> + '_ {
         match self {
             Action::KeyCode(kc) => core::slice::from_ref(kc).iter().cloned(),
             Action::MultipleKeyCodes(kcs) => kcs.iter().cloned(),

--- a/src/key_code.rs
+++ b/src/key_code.rs
@@ -258,14 +258,14 @@ pub enum KeyCode {
 }
 
 impl KeyCode {
-    /// Returns `true` if the key code correspond to a modifier (send
-    /// separately on USB HID report).
+    /// Returns `true` if the key code corresponds to a modifier (sent
+    /// separately on the USB HID report).
     pub fn is_modifier(self) -> bool {
         KeyCode::LCtrl <= self && self <= KeyCode::RGui
     }
 
     /// Returns the byte with the bit corresponding to the USB HID
-    /// modifier bitfield setted.
+    /// modifier bitfield set.
     pub fn as_modifier_bit(self) -> u8 {
         if self.is_modifier() {
             1 << (self as u8 - KeyCode::LCtrl as u8)
@@ -301,7 +301,7 @@ impl KbHidReport {
     }
 
     /// Add the given key code to the report. If the report is full,
-    /// it will be setted to `ErrorRollOver`.
+    /// it will be set to `ErrorRollOver`.
     pub fn pressed(&mut self, kc: KeyCode) {
         use KeyCode::*;
         match kc {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -138,9 +138,7 @@ impl<T: 'static> State<T> {
         }
     }
     fn tick(&self) -> Option<Self> {
-        match *self {
-            _ => Some(*self),
-        }
+        Some(*self)
     }
     fn release(&self, c: (u8, u8), custom: &mut CustomEvent<T>) -> Option<Self> {
         match *self {
@@ -212,10 +210,7 @@ impl<T> WaitingState<T> {
         }
     }
     fn is_corresponding_release(&self, event: &Event) -> bool {
-        match event {
-            Event::Release(i, j) if (*i, *j) == self.coord => true,
-            _ => false,
-        }
+        matches!(event, Event::Release(i, j) if (*i, *j) == self.coord)
     }
 }
 
@@ -247,7 +242,7 @@ impl<T: 'static> Layout<T> {
         }
     }
     /// Iterates on the key codes of the current state.
-    pub fn keycodes<'a>(&'a self) -> impl Iterator<Item = KeyCode> + 'a {
+    pub fn keycodes(&self) -> impl Iterator<Item = KeyCode> + '_ {
         self.states.iter().filter_map(State::keycode)
     }
     fn waiting_into_hold(&mut self) -> CustomEvent<T> {
@@ -276,7 +271,7 @@ impl<T: 'static> Layout<T> {
     ///
     /// Returns the corresponding `CustomEvent`, allowing to manage
     /// custom actions thanks to the `Action::Custom` variant.
-    pub fn tick<'a>(&'a mut self) -> CustomEvent<T> {
+    pub fn tick(&mut self) -> CustomEvent<T> {
         self.states = self.states.iter().filter_map(State::tick).collect();
         self.stacked.iter_mut().for_each(Stacked::tick);
         match &mut self.waiting {
@@ -310,7 +305,7 @@ impl<T: 'static> Layout<T> {
         }
     }
     /// Register a key event.
-    pub fn event<'a>(&'a mut self, event: Event) {
+    pub fn event(&mut self, event: Event) {
         if let Some(stacked) = self.stacked.push_back(event.into()) {
             self.waiting_into_hold();
             self.unstack(stacked);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -104,7 +104,7 @@ where
     V: ArrayLength<bool>,
     U: ArrayLength<GenericArray<bool, V>>,
 {
-    pub fn iter_pressed<'a>(&'a self) -> impl Iterator<Item = (usize, usize)> + Clone + 'a {
+    pub fn iter_pressed(&self) -> impl Iterator<Item = (usize, usize)> + Clone + '_ {
         self.0.iter().enumerate().flat_map(|(i, r)| {
             r.iter()
                 .enumerate()


### PR DESCRIPTION
Also:
 - Reword a few sentences to be easier to understand,
 - Replace a single-branch match in layout.rs with its contents,
 - Replace a match returning bool with the matches! macro in layout.rs