### PR TITLE
Add max_packet_size to HidDevice to allow differing report sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Made Layout::current_layer public for getting current active layer.
 * Added a procedural macro for defining layouts (`keyberon::layout::layout`)
 * Corrected HID report descriptor
+* Add max_packet_size() to HidDevice to allow differing report sizes
 
 Breaking changes:
 * Update to generic_array 0.14, which is exposed in matrix. The update

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -86,6 +86,8 @@ pub trait HidDevice {
 
     fn protocol(&self) -> Protocol;
 
+    fn max_packet_size(&self) -> u16;
+
     fn report_descriptor(&self) -> &[u8];
 
     fn set_report(&mut self, report_type: ReportType, report_id: u8, data: &[u8])
@@ -103,10 +105,11 @@ pub struct HidClass<'a, B: UsbBus, D: HidDevice> {
 
 impl<B: UsbBus, D: HidDevice> HidClass<'_, B, D> {
     pub fn new(device: D, alloc: &UsbBusAllocator<B>) -> HidClass<'_, B, D> {
+        let max_packet_size = device.max_packet_size();
         HidClass {
             device,
             interface: alloc.interface(),
-            endpoint_interrupt_in: alloc.interrupt(8, 10),
+            endpoint_interrupt_in: alloc.interrupt(max_packet_size, 10),
             expect_interrupt_in_complete: false,
         }
     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -95,6 +95,10 @@ impl<L: Leds> HidDevice for Keyboard<L> {
         Protocol::Keyboard
     }
 
+    fn max_packet_size(&self) -> u16 {
+        8
+    }
+
     fn report_descriptor(&self) -> &[u8] {
         REPORT_DESCRIPTOR
     }


### PR DESCRIPTION
As discussed in #57 , this MR adds support for setting max_packet_size on other HidDevice implementations.

For keyberons `Keyboard` this is implemented as 8 to match its report size.