### PR TITLE
allows default layer to be set externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added a procedural macro for defining layouts (`keyberon::layout::layout`)
 * Corrected HID report descriptor
 * Add max_packet_size() to HidDevice to allow differing report sizes
+* Allows default layer to be set on a Layout externally
 
 Breaking changes:
 * Update to generic_array 0.14, which is exposed in matrix. The update

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -421,9 +421,7 @@ impl<T: 'static> Layout<T> {
                 let _ = self.states.push(LayerModifier { value, coord });
             }
             DefaultLayer(value) => {
-                if *value < self.layers.len() {
-                    self.default_layer = *value
-                }
+                self.set_default_layer(*value);
             }
             Custom(value) => {
                 if self.states.push(State::Custom { value, coord }).is_ok() {
@@ -445,6 +443,13 @@ impl<T: 'static> Layout<T> {
             layer += l;
         }
         layer
+    }
+
+    /// Sets the default layer for the layout
+    pub fn set_default_layer(&mut self, value: usize) {
+        if value < self.layers.len() {
+            self.default_layer = value
+        }
     }
 }
 


### PR DESCRIPTION
I came across a requirement to be able to set the default layer after looking at the result of a custom command.

(I've introduced a menu system on my OLEDs, on a Custom menu select action I need to see if I open a submenu, or select and item. If I select an item, I should close the menu and therefore change the default layer to what ever was set previously)

Small change, but I think useful.