### PR TITLE
Replace generic-array with const generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ readme = "README.md"
 [dependencies]
 keyberon-macros = { version = "0.1.0", path = "./keyberon-macros" }
 either = { version = "1.6", default-features = false }
-generic-array = "0.14"
 embedded-hal = { version = "0.2", features = ["unproven"] }
-usb-device = "0.2.0"
-heapless = "0.5"
+usb-device = "0.2"
+heapless = "0.7"
 arraydeque = { version = "0.4.5", default-features = false }

--- a/src/debounce.rs
+++ b/src/debounce.rs
@@ -7,7 +7,6 @@
 //! duration for keyboard switches.
 
 use crate::layout::Event;
-use core::convert::TryInto;
 use either::Either::*;
 
 /// The debouncer type.
@@ -111,13 +110,8 @@ impl<T: PartialEq> Debouncer<T> {
                     .flat_map(move |(i, (o, n))| {
                         o.into_iter().zip(n.into_iter()).enumerate().filter_map(
                             move |(j, bools)| match bools {
-                                (false, true) => {
-                                    Some(Event::Press(i.try_into().unwrap(), j.try_into().unwrap()))
-                                }
-                                (true, false) => Some(Event::Release(
-                                    i.try_into().unwrap(),
-                                    j.try_into().unwrap(),
-                                )),
+                                (false, true) => Some(Event::Press(i as u8, j as u8)),
+                                (true, false) => Some(Event::Release(i as u8, j as u8)),
                                 _ => None,
                             },
                         )

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -48,7 +48,6 @@ pub use keyberon_macros::*;
 use crate::action::{Action, HoldTapConfig};
 use crate::key_code::KeyCode;
 use arraydeque::ArrayDeque;
-use heapless::consts::U64;
 use heapless::Vec;
 
 use State::*;
@@ -70,7 +69,7 @@ where
 {
     layers: Layers<T>,
     default_layer: usize,
-    states: Vec<State<T>, U64>,
+    states: Vec<State<T>, 64>,
     waiting: Option<WaitingState<T>>,
     stacked: Stack,
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,109 +1,64 @@
 #![allow(missing_docs)]
 
 use embedded_hal::digital::v2::{InputPin, OutputPin};
-use generic_array::{ArrayLength, GenericArray};
-use heapless::Vec;
 
-pub trait HeterogenousArray {
-    type Len;
+pub struct Matrix<C, R, const CS: usize, const RS: usize>
+where
+    C: InputPin,
+    R: OutputPin,
+{
+    cols: [C; CS],
+    rows: [R; RS],
 }
 
-/// Macro to implement a iterator on trait objects from a tuple struct.
-#[macro_export]
-macro_rules! impl_heterogenous_array {
-    ($s:ident, $t:ty, $len:tt, [$($idx:tt),+]) => {
-        impl<'a> IntoIterator for &'a $s {
-            type Item = &'a $t;
-            type IntoIter = generic_array::GenericArrayIter<&'a $t, $len>;
-            fn into_iter(self) -> Self::IntoIter {
-                self.as_array().into_iter()
-            }
-        }
-        impl<'a> IntoIterator for &'a mut $s {
-            type Item = &'a mut $t;
-            type IntoIter = generic_array::GenericArrayIter<&'a mut $t, $len>;
-            fn into_iter(self) -> Self::IntoIter {
-                self.as_mut_array().into_iter()
-            }
-        }
-        impl $crate::matrix::HeterogenousArray for $s {
-            type Len = $len;
-        }
-        impl $s {
-            pub fn as_array(&self) -> generic_array::GenericArray<&$t, $len> {
-                generic_array::arr![&$t; $( &self.$idx as &$t, )+]
-            }
-            pub fn as_mut_array(&mut self) -> generic_array::GenericArray<&mut $t, $len> {
-                generic_array::arr![&mut $t; $( &mut self.$idx as &mut $t, )+]
-            }
-        }
-    }
-}
-
-pub struct Matrix<C, R> {
-    cols: C,
-    rows: R,
-}
-
-impl<C, R> Matrix<C, R> {
-    pub fn new<E>(cols: C, rows: R) -> Result<Self, E>
+impl<C, R, const CS: usize, const RS: usize> Matrix<C, R, CS, RS>
+where
+    C: InputPin,
+    R: OutputPin,
+{
+    pub fn new<E>(cols: [C; CS], rows: [R; RS]) -> Result<Self, E>
     where
-        for<'a> &'a mut R: IntoIterator<Item = &'a mut dyn OutputPin<Error = E>>,
+        C: InputPin<Error = E>,
+        R: OutputPin<Error = E>,
     {
         let mut res = Self { cols, rows };
         res.clear()?;
         Ok(res)
     }
-    pub fn clear<'a, E: 'a>(&'a mut self) -> Result<(), E>
+    pub fn clear<E>(&mut self) -> Result<(), E>
     where
-        &'a mut R: IntoIterator<Item = &'a mut dyn OutputPin<Error = E>>,
+        C: InputPin<Error = E>,
+        R: OutputPin<Error = E>,
     {
-        for r in self.rows.into_iter() {
+        for r in self.rows.iter_mut() {
             r.set_high()?;
         }
         Ok(())
     }
-    pub fn get<'a, E: 'a>(&'a mut self) -> Result<PressedKeys<R::Len, C::Len>, E>
+    pub fn get<E>(&mut self) -> Result<PressedKeys<CS, RS>, E>
     where
-        &'a mut R: IntoIterator<Item = &'a mut dyn OutputPin<Error = E>>,
-        R: HeterogenousArray,
-        R::Len: ArrayLength<GenericArray<bool, C::Len>>,
-        R::Len: heapless::ArrayLength<GenericArray<bool, C::Len>>,
-        &'a C: IntoIterator<Item = &'a dyn InputPin<Error = E>>,
-        C: HeterogenousArray,
-        C::Len: ArrayLength<bool>,
-        C::Len: heapless::ArrayLength<bool>,
+        C: InputPin<Error = E>,
+        R: OutputPin<Error = E>,
     {
-        let cols = &self.cols;
-        self.rows
-            .into_iter()
-            .map(|r| {
-                r.set_low()?;
-                let col = cols
-                    .into_iter()
-                    .map(|c| c.is_low())
-                    .collect::<Result<Vec<_, C::Len>, E>>()?
-                    .into_iter()
-                    .collect();
-                r.set_high()?;
-                Ok(col)
-            })
-            .collect::<Result<Vec<_, R::Len>, E>>()
-            .map(|res| PressedKeys(res.into_iter().collect()))
+        let mut keys = PressedKeys::default();
+
+        for (ri, row) in (&mut self.rows).iter_mut().enumerate() {
+            row.set_low()?;
+            for (ci, col) in (&self.cols).iter().enumerate() {
+                if col.is_low()? {
+                    keys.0[ri][ci] = true;
+                }
+            }
+            row.set_high()?;
+        }
+        Ok(keys)
     }
 }
 
-#[derive(Default, PartialEq, Eq)]
-pub struct PressedKeys<U, V>(pub GenericArray<GenericArray<bool, V>, U>)
-where
-    V: ArrayLength<bool>,
-    U: ArrayLength<GenericArray<bool, V>>;
+#[derive(PartialEq, Eq)]
+pub struct PressedKeys<const C: usize, const R: usize>(pub [[bool; C]; R]);
 
-impl<U, V> PressedKeys<U, V>
-where
-    V: ArrayLength<bool>,
-    U: ArrayLength<GenericArray<bool, V>>,
-{
+impl<const C: usize, const R: usize> PressedKeys<C, R> {
     pub fn iter_pressed(&self) -> impl Iterator<Item = (usize, usize)> + Clone + '_ {
         self.0.iter().enumerate().flat_map(|(i, r)| {
             r.iter()
@@ -113,14 +68,15 @@ where
     }
 }
 
-impl<'a, U, V> IntoIterator for &'a PressedKeys<U, V>
-where
-    V: ArrayLength<bool>,
-    U: ArrayLength<GenericArray<bool, V>>,
-    U: ArrayLength<&'a GenericArray<bool, V>>,
-{
-    type IntoIter = core::slice::Iter<'a, GenericArray<bool, V>>;
-    type Item = &'a GenericArray<bool, V>;
+impl<const C: usize, const R: usize> Default for PressedKeys<C, R> {
+    fn default() -> Self {
+        PressedKeys([[false; C]; R])
+    }
+}
+
+impl<'a, const C: usize, const R: usize> IntoIterator for &'a PressedKeys<C, R> {
+    type IntoIter = core::slice::Iter<'a, [bool; C]>;
+    type Item = &'a [bool; C];
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
     }


### PR DESCRIPTION
Now that const generics are stable (and heapless 0.7 uses them), we no longer need to relay on generic-array. It also makes the crate easier to use, faster and reduces code size by around 2-3KB on average: (results of running `cargo size --release` before and after only updating keyberon by this commit on my keyboard's firmware)
```
before:
   text    data     bss     dec     hex filename
  20420       0    1156   21576    5448 firmware

after:
   text    data     bss     dec     hex filename
  17140       0    1276   18416    47f0 firmware
```
## Usage changes
Now the user doesn't need to create tuple structs for columns and rows containing the pins - the `Matrix` struct now accepts two arrays: `[InputPin; const usize]` for column pins and `[OutputPin; const usize]` for row pins. This also allows us to skip all the `IntoIter` bounds as arrays implement iterators themselves.
Example change:
```diff
-        matrix: Matrix<layout::Cols, layout::Rows>,
+        matrix: Matrix<gpio::Pin<Input<PullUp>>, gpio::Pin<Output<PushPull>>, 6, 4>,
// The ordering of Debouncer's generic arguments is changed to match Matrix's
-        debouncer: Debouncer<PressedKeys<U4, U6>>,
+        debouncer: Debouncer<PressedKeys<6, 4>>,
```
*Important note:* In order to be able to put different pin structs in an array, they have to be downgraded (stripped of their numbers etc): see (for example) [gpio::PA0::downgrade](https://docs.rs/stm32f0xx-hal/0.17.1/stm32f0xx_hal/gpio/gpioa/struct.PA0.html#method.downgrade). Every HAL should have a method of downgrading pins to a common (erased) struct in order to be able put pins in an array. Example:
```rust
Matrix::new(
    // This has type [Pin<Input<PullUp>>; 6]
    [
        pa0.into_pull_up_input(cs).downgrade(),
        pa1.into_pull_up_input(cs).downgrade(),
        pa2.into_pull_up_input(cs).downgrade(),
        pa3.into_pull_up_input(cs).downgrade(),
        pa4.into_pull_up_input(cs).downgrade(),
        pa5.into_pull_up_input(cs).downgrade(),
    ],
    // This has type [Pin<Output<PushPull>>; 4]
    [
        pb4.into_push_pull_output(cs).downgrade(),
        pb5.into_push_pull_output(cs).downgrade(),
        pb6.into_push_pull_output(cs).downgrade(),
        pb7.into_push_pull_output(cs).downgrade(),
    ],
)
// And that's all! No need for any separate structs or impls.
```

This PR also removes the need for the `impl_heterogeneous_arrays` macro, resolving #16.

**This is (obviously) a breaking change.** Though I guess that if we're about to release keyberon 0.2 this isn't a big issue.

This PR has been tested on hardware.

Changes:
 - Remove unnecessary unwraps to reduce code size
 - Change Matrix to store pin arrays directly instead of
   relaying on user-defined into_iter impl
 - Remove impl_heterogeneous_array macro
 - Change PressedKeys generic argument order to match Matrix
 - Up the usb-device version