### PR TITLE
Fully const layouts

### DIFF
--- a/keyberon-macros/src/lib.rs
+++ b/keyberon-macros/src/lib.rs
@@ -18,14 +18,14 @@ pub fn layout(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => {
                 let layer = parse_layer(g.stream());
                 inside.extend(quote! {
-                    &[#layer],
+                    [#layer],
                 });
             }
             _ => abort!(t, "Invalid token, expected layer: {{ ... }}"),
         }
     }
 
-    let all: TokenStream = quote! { &[#inside] };
+    let all: TokenStream = quote! { [#inside] };
     out.extend(all);
 
     out.into()
@@ -38,7 +38,7 @@ fn parse_layer(input: TokenStream) -> TokenStream {
             TokenTree::Group(g) if g.delimiter() == Delimiter::Bracket => {
                 let row = parse_row(g.stream());
                 out.extend(quote! {
-                    &[#row],
+                    [#row],
                 });
             }
             TokenTree::Punct(p) if p.as_char() == ',' => (),

--- a/keyberon-macros/tests/mod.rs
+++ b/keyberon-macros/tests/mod.rs
@@ -1,6 +1,7 @@
 extern crate keyberon_macros;
 use keyberon::action::{k, l, m, Action, Action::*, HoldTapConfig};
 use keyberon::key_code::KeyCode::*;
+use keyberon::layout::*;
 use keyberon_macros::layout;
 
 #[test]
@@ -20,22 +21,22 @@ fn test_layout_equality() {
     };
 
     #[rustfmt::skip]
-    pub static LAYERS_OLD: keyberon::layout::Layers = &[
-        &[
-            &[k(Tab),    k(Q), k(W), k(E), k(R), k(T),   k(Y), k(U), k(I),     k(O),   k(P),      k(BSpace)],
-            &[k(LCtrl),  k(A), k(S), k(D), k(F), k(G),   k(H), k(J), k(K),     k(L),   k(SColon), k(Quote) ],
-            &[k(LShift), k(Z), k(X), k(C), k(V), k(B),   k(N), k(M), k(Comma), k(Dot), k(Slash),  k(Escape)],
-            &[NoOp, NoOp, k(LGui), l(1), k(Space), k(Escape),   k(BSpace), S_ENTER, l(1), k(RAlt), NoOp, NoOp],
+    pub static LAYERS_OLD: Layers<NoCustom, 12, 4, 2> = [
+        [
+            [k(Tab),    k(Q), k(W), k(E), k(R), k(T),   k(Y), k(U), k(I),     k(O),   k(P),      k(BSpace)],
+            [k(LCtrl),  k(A), k(S), k(D), k(F), k(G),   k(H), k(J), k(K),     k(L),   k(SColon), k(Quote) ],
+            [k(LShift), k(Z), k(X), k(C), k(V), k(B),   k(N), k(M), k(Comma), k(Dot), k(Slash),  k(Escape)],
+            [NoOp, NoOp, k(LGui), l(1), k(Space), k(Escape),   k(BSpace), S_ENTER, l(1), k(RAlt), NoOp, NoOp],
         ],
-        &[
-            &[k(Tab),    k(Kb1), k(Kb2), k(Kb3), k(Kb4), k(Kb5),   k(Kb6),  k(Kb7),  k(Kb8), k(Kb9), k(Kb0), k(BSpace)],
-            &[k(LCtrl),  s!(Kb1), s!(Kb2), s!(Kb3), s!(Kb4), s!(Kb5),   s!(Kb6), s!(Kb7), s!(Kb8),  s!(Kb9), s!(Kb0), MultipleActions(&[k(LCtrl), k(Grave)])],
-            &[k(LShift), NoOp, NoOp, NoOp, NoOp, NoOp,   k(Left), k(Down), k(Up), k(Right), NoOp, s!(Grave)],
-            &[NoOp, NoOp, k(LGui), Trans, Trans, Trans,   Trans, Trans, Trans, k(RAlt), NoOp, NoOp],
+        [
+            [k(Tab),    k(Kb1), k(Kb2), k(Kb3), k(Kb4), k(Kb5),   k(Kb6),  k(Kb7),  k(Kb8), k(Kb9), k(Kb0), k(BSpace)],
+            [k(LCtrl),  s!(Kb1), s!(Kb2), s!(Kb3), s!(Kb4), s!(Kb5),   s!(Kb6), s!(Kb7), s!(Kb8),  s!(Kb9), s!(Kb0), MultipleActions(&[k(LCtrl), k(Grave)])],
+            [k(LShift), NoOp, NoOp, NoOp, NoOp, NoOp,   k(Left), k(Down), k(Up), k(Right), NoOp, s!(Grave)],
+            [NoOp, NoOp, k(LGui), Trans, Trans, Trans,   Trans, Trans, Trans, k(RAlt), NoOp, NoOp],
         ],
     ];
 
-    pub static LAYERS: keyberon::layout::Layers = layout! {
+    pub static LAYERS: Layers<NoCustom, 12, 4, 2> = layout! {
         {
             [ Tab    Q W E R T   Y U I O P BSpace ]
             [ LCtrl  A S D F G   H J K L ; Quote  ]
@@ -52,17 +53,17 @@ fn test_layout_equality() {
 
     assert_eq!(LAYERS, LAYERS_OLD);
     use std::mem::size_of_val;
-    assert_eq!(size_of_val(LAYERS), size_of_val(LAYERS_OLD))
+    assert_eq!(size_of_val(&LAYERS), size_of_val(&LAYERS_OLD))
 }
 
 #[test]
 fn test_nesting() {
-    static A: keyberon::layout::Layers = layout! {
+    static A: Layers<NoCustom, 2, 1, 1> = layout! {
         {
             [{k(D)} [(5) [C {k(D)}]]]
         }
     };
-    static B: keyberon::layout::Layers = &[&[&[
+    static B: Layers<NoCustom, 2, 1, 1> = [[[
         k(D),
         Action::MultipleActions(&[Action::Layer(5), Action::MultipleActions(&[k(C), k(D)])]),
     ]]];
@@ -71,20 +72,28 @@ fn test_nesting() {
 
 #[test]
 fn test_layer_switch() {
-    static A: keyberon::layout::Layers = layout! {
+    static A: Layers<NoCustom, 5, 1, 1> = layout! {
         {
-            [(0xa), (0b0110), (b'a' as usize), (1 + 8 & 32), ([4,5][0])]
+            [(0xa) (0b0110) (b'a' as usize) (1 + 8 & 32) ([4,5][0])]
         }
     };
+    static B: Layers<NoCustom, 5, 1, 1> = [[[
+        Action::Layer(0xa),
+        Action::Layer(6),
+        Action::Layer(b'a' as usize),
+        Action::Layer(1 + 8 & 32),
+        Action::Layer([4, 5][0]),
+    ]]];
+    assert_eq!(A, B);
 }
 
 #[test]
 fn test_escapes() {
-    static A: keyberon::layout::Layers = layout! {
+    static A: Layers<NoCustom, 2, 1, 1> = layout! {
         {
             ['\\' '\'']
         }
     };
-    static B: keyberon::layout::Layers = &[&[&[k(Bslash), k(Quote)]]];
+    static B: Layers<NoCustom, 2, 1, 1> = [[[k(Bslash), k(Quote)]]];
     assert_eq!(A, B);
 }

--- a/keyberon-macros/tests/mod.rs
+++ b/keyberon-macros/tests/mod.rs
@@ -21,7 +21,7 @@ fn test_layout_equality() {
     };
 
     #[rustfmt::skip]
-    pub static LAYERS_OLD: Layers<NoCustom, 12, 4, 2> = [
+    pub static LAYERS_OLD: Layers<12, 4, 2> = [
         [
             [k(Tab),    k(Q), k(W), k(E), k(R), k(T),   k(Y), k(U), k(I),     k(O),   k(P),      k(BSpace)],
             [k(LCtrl),  k(A), k(S), k(D), k(F), k(G),   k(H), k(J), k(K),     k(L),   k(SColon), k(Quote) ],
@@ -36,7 +36,7 @@ fn test_layout_equality() {
         ],
     ];
 
-    pub static LAYERS: Layers<NoCustom, 12, 4, 2> = layout! {
+    pub static LAYERS: Layers<12, 4, 2> = layout! {
         {
             [ Tab    Q W E R T   Y U I O P BSpace ]
             [ LCtrl  A S D F G   H J K L ; Quote  ]
@@ -58,12 +58,12 @@ fn test_layout_equality() {
 
 #[test]
 fn test_nesting() {
-    static A: Layers<NoCustom, 2, 1, 1> = layout! {
+    static A: Layers<2, 1, 1> = layout! {
         {
             [{k(D)} [(5) [C {k(D)}]]]
         }
     };
-    static B: Layers<NoCustom, 2, 1, 1> = [[[
+    static B: Layers<2, 1, 1> = [[[
         k(D),
         Action::MultipleActions(&[Action::Layer(5), Action::MultipleActions(&[k(C), k(D)])]),
     ]]];
@@ -72,12 +72,12 @@ fn test_nesting() {
 
 #[test]
 fn test_layer_switch() {
-    static A: Layers<NoCustom, 5, 1, 1> = layout! {
+    static A: Layers<5, 1, 1> = layout! {
         {
             [(0xa) (0b0110) (b'a' as usize) (1 + 8 & 32) ([4,5][0])]
         }
     };
-    static B: Layers<NoCustom, 5, 1, 1> = [[[
+    static B: Layers<5, 1, 1> = [[[
         Action::Layer(0xa),
         Action::Layer(6),
         Action::Layer(b'a' as usize),
@@ -89,11 +89,11 @@ fn test_layer_switch() {
 
 #[test]
 fn test_escapes() {
-    static A: Layers<NoCustom, 2, 1, 1> = layout! {
+    static A: Layers<2, 1, 1> = layout! {
         {
             ['\\' '\'']
         }
     };
-    static B: Layers<NoCustom, 2, 1, 1> = [[[k(Bslash), k(Quote)]]];
+    static B: Layers<2, 1, 1> = [[[k(Bslash), k(Quote)]]];
     assert_eq!(A, B);
 }

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -16,7 +16,7 @@
 /// ## Usage
 /// ```
 /// use keyberon::chording::{Chording, ChordDef};
-/// use keyberon::layout::{Layout, Event::*, Event};
+/// use keyberon::layout::{NoCustom, Layout, Event::*, Event};
 /// use keyberon::debounce::Debouncer;
 /// use keyberon::matrix::{Matrix, PressedKeys};
 ///
@@ -29,11 +29,11 @@
 /// // A count of 30 (ms) is a good default
 /// const DEBOUNCE_COUNT: u16 = 30;
 ///
-/// pub static LAYERS: keyberon::layout::Layers = keyberon::layout::layout! {
+/// pub static LAYERS: keyberon::layout::Layers<NoCustom, 3, 1, 1> = keyberon::layout::layout! {
 ///     { [ A B C ] }
 /// };
 ///
-/// let mut layout = Layout::new(LAYERS);
+/// let mut layout = Layout::new(&LAYERS);
 /// // Debouncer period determines chording timeout
 /// let mut debouncer: Debouncer<PressedKeys<3, 1>> =
 ///     Debouncer::new(PressedKeys::default(), PressedKeys::default(), DEBOUNCE_COUNT);
@@ -102,10 +102,9 @@ impl Chord {
 
     fn contains_chord(&mut self, events: &[Event]) -> bool {
         for key in self.def.1 {
-            if events
+            if !events
                 .iter()
-                .position(|&k| (&k.coord() == key && k.is_press()))
-                .is_none()
+                .any(|&k| (&k.coord() == key && k.is_press()))
             {
                 return false;
             }

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -16,7 +16,7 @@
 /// ## Usage
 /// ```
 /// use keyberon::chording::{Chording, ChordDef};
-/// use keyberon::layout::{NoCustom, Layout, Event::*, Event};
+/// use keyberon::layout::{Layout, Event::*, Event};
 /// use keyberon::debounce::Debouncer;
 /// use keyberon::matrix::{Matrix, PressedKeys};
 ///
@@ -29,7 +29,7 @@
 /// // A count of 30 (ms) is a good default
 /// const DEBOUNCE_COUNT: u16 = 30;
 ///
-/// pub static LAYERS: keyberon::layout::Layers<NoCustom, 3, 1, 1> = keyberon::layout::layout! {
+/// pub static LAYERS: keyberon::layout::Layers<3, 1, 1> = keyberon::layout::layout! {
 ///     { [ A B C ] }
 /// };
 ///
@@ -102,10 +102,7 @@ impl Chord {
 
     fn contains_chord(&mut self, events: &[Event]) -> bool {
         for key in self.def.1 {
-            if !events
-                .iter()
-                .any(|&k| (&k.coord() == key && k.is_press()))
-            {
+            if !events.iter().any(|&k| (&k.coord() == key && k.is_press())) {
                 return false;
             }
         }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -25,9 +25,10 @@
 /// Example layout for a 4x12 split keyboard:
 /// ```
 /// use keyberon::action::Action;
+/// use keyberon::layout::{Layers, NoCustom};
 /// static DLAYER: Action = Action::DefaultLayer(5);
 ///
-/// pub static LAYERS: keyberon::layout::Layers = keyberon::layout::layout! {
+/// pub static LAYERS: Layers<NoCustom, 12, 4, 2> = keyberon::layout::layout! {
 ///     {
 ///         [ Tab    Q W E R T   Y U I O P BSpace ]
 ///         [ LCtrl  A S D F G   H J K L ; Quote  ]
@@ -36,7 +37,7 @@
 ///     }
 ///     {
 ///         [ Tab    1 2 3 4 5   6 7 8 9 0 BSpace  ]
-///         [ LCtrl  ! @ # $ %   ^ & * '(' ')' - = ]
+///         [ LCtrl  ! @ # $ %   ^ & * '(' ')' -   ]
 ///         [ LShift n n n n n   n n n n n [LAlt A]]
 ///         [ n n LGui (2) t t   t t t RAlt n n    ]
 ///     }
@@ -57,17 +58,20 @@ use State::*;
 /// The first level correspond to the layer, the two others to the
 /// switch matrix.  For example, `layers[1][2][3]` correspond to the
 /// key i=2, j=3 on the layer 1.
-pub type Layers<T = core::convert::Infallible> = &'static [&'static [&'static [Action<T>]]];
+pub type Layers<T, const C: usize, const R: usize, const L: usize> = [[[Action<T>; C]; R]; L];
 
 type Stack = ArrayDeque<[Stacked; 16], arraydeque::behavior::Wrapping>;
 
+/// Indicates that the layout doesn't contain user-defined actions ([Action::Custom])
+pub type NoCustom = core::convert::Infallible;
+
 /// The layout manager. It takes `Event`s and `tick`s as input, and
 /// generate keyboard reports.
-pub struct Layout<T = core::convert::Infallible>
+pub struct Layout<T, const C: usize, const R: usize, const L: usize>
 where
     T: 'static,
 {
-    layers: Layers<T>,
+    layers: &'static [[[Action<T>; C]; R]; L],
     default_layer: usize,
     states: Vec<State<T>, 64>,
     waiting: Option<WaitingState<T>>,
@@ -202,7 +206,7 @@ impl<T: 'static> State<T> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 struct WaitingState<T: 'static> {
     coord: (u8, u8),
     timeout: u16,
@@ -274,9 +278,9 @@ impl Stacked {
     }
 }
 
-impl<T: 'static> Layout<T> {
+impl<T: 'static, const C: usize, const R: usize, const L: usize> Layout<T, C, R, L> {
     /// Creates a new `Layout` object.
-    pub fn new(layers: Layers<T>) -> Self {
+    pub fn new(layers: &'static [[[Action<T>; C]; R]; L]) -> Self {
         Self {
             layers,
             default_layer: 0,
@@ -384,7 +388,7 @@ impl<T: 'static> Layout<T> {
         use Action::*;
         match action {
             NoOp | Trans => (),
-            &HoldTap {
+            HoldTap {
                 timeout,
                 hold,
                 tap,
@@ -393,11 +397,11 @@ impl<T: 'static> Layout<T> {
             } => {
                 let waiting: WaitingState<T> = WaitingState {
                     coord,
-                    timeout,
+                    timeout: *timeout,
                     delay,
                     hold,
                     tap,
-                    config,
+                    config: *config,
                 };
                 self.waiting = Some(waiting);
             }
@@ -452,7 +456,7 @@ impl<T: 'static> Layout<T> {
 #[cfg(test)]
 mod test {
     extern crate std;
-    use super::{Event::*, Layers, Layout, *};
+    use super::{Event::*, Layout, *};
     use crate::action::Action::*;
     use crate::action::HoldTapConfig;
     use crate::action::{k, l, m};
@@ -469,8 +473,8 @@ mod test {
 
     #[test]
     fn basic_hold_tap() {
-        static LAYERS: Layers = &[
-            &[&[
+        static LAYERS: Layers<NoCustom, 2, 1, 2> = [
+            [[
                 HoldTap {
                     timeout: 200,
                     hold: &l(1),
@@ -486,9 +490,9 @@ mod test {
                     tap_hold_interval: 0,
                 },
             ]],
-            &[&[Trans, m(&[LCtrl, Enter])]],
+            [[Trans, m(&[LCtrl, Enter])]],
         ];
-        let mut layout = Layout::new(LAYERS);
+        let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[], layout.keycodes());
         layout.event(Press(0, 1));
@@ -519,7 +523,7 @@ mod test {
 
     #[test]
     fn hold_tap_interleaved_timeout() {
-        static LAYERS: Layers = &[&[&[
+        static LAYERS: Layers<NoCustom, 2, 1, 1> = [[[
             HoldTap {
                 timeout: 200,
                 hold: &k(LAlt),
@@ -535,7 +539,7 @@ mod test {
                 tap_hold_interval: 0,
             },
         ]]];
-        let mut layout = Layout::new(LAYERS);
+        let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[], layout.keycodes());
         layout.event(Press(0, 0));
@@ -566,7 +570,7 @@ mod test {
 
     #[test]
     fn hold_on_press() {
-        static LAYERS: Layers = &[&[&[
+        static LAYERS: Layers<NoCustom, 2, 1, 1> = [[[
             HoldTap {
                 timeout: 200,
                 hold: &k(LAlt),
@@ -576,7 +580,7 @@ mod test {
             },
             k(Enter),
         ]]];
-        let mut layout = Layout::new(LAYERS);
+        let mut layout = Layout::new(&LAYERS);
 
         // Press another key before timeout
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -623,7 +627,7 @@ mod test {
 
     #[test]
     fn permissive_hold() {
-        static LAYERS: Layers = &[&[&[
+        static LAYERS: Layers<NoCustom, 2, 1, 1> = [[[
             HoldTap {
                 timeout: 200,
                 hold: &k(LAlt),
@@ -633,7 +637,7 @@ mod test {
             },
             k(Enter),
         ]]];
-        let mut layout = Layout::new(LAYERS);
+        let mut layout = Layout::new(&LAYERS);
 
         // Press and release another key before timeout
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -662,11 +666,11 @@ mod test {
 
     #[test]
     fn multiple_actions() {
-        static LAYERS: Layers = &[
-            &[&[MultipleActions(&[l(1), k(LShift)]), k(F)]],
-            &[&[Trans, k(E)]],
+        static LAYERS: Layers<NoCustom, 2, 1, 2> = [
+            [[MultipleActions(&[l(1), k(LShift)]), k(F)]],
+            [[Trans, k(E)]],
         ];
-        let mut layout = Layout::new(LAYERS);
+        let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[], layout.keycodes());
         layout.event(Press(0, 0));
@@ -685,8 +689,8 @@ mod test {
 
     #[test]
     fn custom() {
-        static LAYERS: Layers<u8> = &[&[&[Action::Custom(42)]]];
-        let mut layout = Layout::new(LAYERS);
+        static LAYERS: Layers<u8, 1, 1, 1> = [[[Action::Custom(42)]]];
+        let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[], layout.keycodes());
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -55,9 +55,13 @@ use State::*;
 
 /// The Layers type.
 ///
-/// The first level correspond to the layer, the two others to the
-/// switch matrix.  For example, `layers[1][2][3]` correspond to the
-/// key i=2, j=3 on the layer 1.
+/// `Layers` type is an array of layers which contain the description
+/// of actions on the switch matrix. For example `layers[1][2][3]`
+/// corresponds to the key on the first layer, row 2, column 3.
+/// The generic parameters are in order: The type contained in custom actions,
+/// the number of columns, rows and layers.
+/// If no custom actions are used the first parameter should be specified as
+/// `keyberon::layout::NoCustom` (or `core::convert::Infallible`).
 pub type Layers<T, const C: usize, const R: usize, const L: usize> = [[[Action<T>; C]; R]; L];
 
 type Stack = ArrayDeque<[Stacked; 16], arraydeque::behavior::Wrapping>;
@@ -711,13 +715,13 @@ mod test {
 
     #[test]
     fn multiple_layers() {
-        static LAYERS: Layers = &[
-            &[&[l(1), l(2)]],
-            &[&[k(A), l(3)]],
-            &[&[l(0), k(B)]],
-            &[&[k(C), k(D)]],
+        static LAYERS: Layers<NoCustom, 2, 1, 4> = [
+            [[l(1), l(2)]],
+            [[k(A), l(3)]],
+            [[l(0), k(B)]],
+            [[k(C), k(D)]],
         ];
-        let mut layout = Layout::new(LAYERS);
+        let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_eq!(0, layout.current_layer());
         assert_keys(&[], layout.keycodes());

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -22,13 +22,13 @@
 /// to do when not using a macro.
 ///
 /// ## Usage example:
-/// Example layout for a 4x12 split keyboard:
+/// Example layout for a 12x4 split keyboard:
 /// ```
 /// use keyberon::action::Action;
-/// use keyberon::layout::{Layers, NoCustom};
+/// use keyberon::layout::Layers;
 /// static DLAYER: Action = Action::DefaultLayer(5);
 ///
-/// pub static LAYERS: Layers<NoCustom, 12, 4, 2> = keyberon::layout::layout! {
+/// pub static LAYERS: Layers<12, 4, 2> = keyberon::layout::layout! {
 ///     {
 ///         [ Tab    Q W E R T   Y U I O P BSpace ]
 ///         [ LCtrl  A S D F G   H J K L ; Quote  ]
@@ -58,16 +58,12 @@ use State::*;
 /// `Layers` type is an array of layers which contain the description
 /// of actions on the switch matrix. For example `layers[1][2][3]`
 /// corresponds to the key on the first layer, row 2, column 3.
-/// The generic parameters are in order: The type contained in custom actions,
-/// the number of columns, rows and layers.
-/// If no custom actions are used the first parameter should be specified as
-/// `keyberon::layout::NoCustom` (or `core::convert::Infallible`).
-pub type Layers<T, const C: usize, const R: usize, const L: usize> = [[[Action<T>; C]; R]; L];
+/// The generic parameters are in order: the number of columns, rows and layers,
+/// and the type contained in custom actions.
+pub type Layers<const C: usize, const R: usize, const L: usize, T = core::convert::Infallible> =
+    [[[Action<T>; C]; R]; L];
 
 type Stack = ArrayDeque<[Stacked; 16], arraydeque::behavior::Wrapping>;
-
-/// Indicates that the layout doesn't contain user-defined actions ([Action::Custom])
-pub type NoCustom = core::convert::Infallible;
 
 /// The layout manager. It takes `Event`s and `tick`s as input, and
 /// generate keyboard reports.
@@ -477,7 +473,7 @@ mod test {
 
     #[test]
     fn basic_hold_tap() {
-        static LAYERS: Layers<NoCustom, 2, 1, 2> = [
+        static LAYERS: Layers<2, 1, 2> = [
             [[
                 HoldTap {
                     timeout: 200,
@@ -527,7 +523,7 @@ mod test {
 
     #[test]
     fn hold_tap_interleaved_timeout() {
-        static LAYERS: Layers<NoCustom, 2, 1, 1> = [[[
+        static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap {
                 timeout: 200,
                 hold: &k(LAlt),
@@ -574,7 +570,7 @@ mod test {
 
     #[test]
     fn hold_on_press() {
-        static LAYERS: Layers<NoCustom, 2, 1, 1> = [[[
+        static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap {
                 timeout: 200,
                 hold: &k(LAlt),
@@ -631,7 +627,7 @@ mod test {
 
     #[test]
     fn permissive_hold() {
-        static LAYERS: Layers<NoCustom, 2, 1, 1> = [[[
+        static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap {
                 timeout: 200,
                 hold: &k(LAlt),
@@ -670,7 +666,7 @@ mod test {
 
     #[test]
     fn multiple_actions() {
-        static LAYERS: Layers<NoCustom, 2, 1, 2> = [
+        static LAYERS: Layers<2, 1, 2> = [
             [[MultipleActions(&[l(1), k(LShift)]), k(F)]],
             [[Trans, k(E)]],
         ];
@@ -693,7 +689,7 @@ mod test {
 
     #[test]
     fn custom() {
-        static LAYERS: Layers<u8, 1, 1, 1> = [[[Action::Custom(42)]]];
+        static LAYERS: Layers<1, 1, 1, u8> = [[[Action::Custom(42)]]];
         let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
         assert_keys(&[], layout.keycodes());
@@ -715,7 +711,7 @@ mod test {
 
     #[test]
     fn multiple_layers() {
-        static LAYERS: Layers<NoCustom, 2, 1, 4> = [
+        static LAYERS: Layers<2, 1, 4> = [
             [[l(1), l(2)]],
             [[k(A), l(3)]],
             [[l(0), k(B)]],

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3,6 +3,7 @@
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 /// Describes the hardware-level matrix of switches.
+///
 /// Generic parameters are in order: The type of column pins,
 /// the type of row pins, the number of columns and rows.
 /// **NOTE:** In order to be able to put different pin structs
@@ -24,8 +25,10 @@ where
     C: InputPin,
     R: OutputPin,
 {
-    // Creates a new Matrix; assumes columns are pull-up inputs,
-    // and rows are output pins which are set high when not being scanned.
+    /// Creates a new Matrix.
+    /// 
+    /// Assumes columns are pull-up inputs,
+    /// and rows are output pins which are set high when not being scanned.
     pub fn new<E>(cols: [C; CS], rows: [R; RS]) -> Result<Self, E>
     where
         C: InputPin<Error = E>,
@@ -45,9 +48,10 @@ where
         }
         Ok(())
     }
-    // Scans the matrix and checks which keys are pressed.
-    // Every row pin in order is pulled low, and then each column
-    // pin is tested; if it's low, the key is marked as pressed.
+    /// Scans the matrix and checks which keys are pressed.
+    ///
+    /// Every row pin in order is pulled low, and then each column
+    /// pin is tested; if it's low, the key is marked as pressed.
     pub fn get<E>(&mut self) -> Result<PressedKeys<CS, RS>, E>
     where
         C: InputPin<Error = E>,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -2,6 +2,14 @@
 
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 
+/// Describes the hardware-level matrix of switches.
+/// Generic parameters are in order: The type of column pins,
+/// the type of row pins, the number of columns and rows.
+/// **NOTE:** In order to be able to put different pin structs
+/// in an array they have to be downgraded (stripped of their
+/// numbers etc.). Most HAL-s have a method of downgrading pins
+/// to a common (erased) struct. (for example see
+/// [stm32f0xx_hal::gpio::PA0::downgrade](https://docs.rs/stm32f0xx-hal/0.17.1/stm32f0xx_hal/gpio/gpioa/struct.PA0.html#method.downgrade))
 pub struct Matrix<C, R, const CS: usize, const RS: usize>
 where
     C: InputPin,
@@ -16,6 +24,8 @@ where
     C: InputPin,
     R: OutputPin,
 {
+    // Creates a new Matrix; assumes columns are pull-up inputs,
+    // and rows are output pins which are set high when not being scanned.
     pub fn new<E>(cols: [C; CS], rows: [R; RS]) -> Result<Self, E>
     where
         C: InputPin<Error = E>,
@@ -35,6 +45,9 @@ where
         }
         Ok(())
     }
+    // Scans the matrix and checks which keys are pressed.
+    // Every row pin in order is pulled low, and then each column
+    // pin is tested; if it's low, the key is marked as pressed.
     pub fn get<E>(&mut self) -> Result<PressedKeys<CS, RS>, E>
     where
         C: InputPin<Error = E>,


### PR DESCRIPTION
This commit introduces fully const layouts - instead of
```rust
pub type Layers<T = core::convert::Infallible> = &'static [&'static [&'static [Action<T>]]];
```
now there's
```rust
pub type Layers<T, const C: usize, const R: usize, const L: usize> = [[[Action<T>; C]; R]; L];
```
This makes sure that the layout's layer count, row count and keycode count matches exactly what the user specified; protects against errors when too many or too little keycodes were specified in the layout, resulting in weird runtime behaviour (it even went unnoticed in line 40 in src/layout.rs, which also gets fixed in this PR), but also simplifies layout declaration a little (as seen in tests).

The only issue for now is that [default parameters with const generics](https://github.com/rust-lang/rust/issues/44580) are not yet supported (on stable) - meaning that the `T` in `Action<T>` has to be always specified. The simplest solution that I found is aliasing `core::convert::Infallible` to a name like `NoCustom`, which means that when the user doesn't need any custom actions, the layout declaration looks like this:
```rust
let layers = Layers<NoCustom, 12, 6, 2> = (...)
```
This also holds back some of rust's automatic type inference, meaning that unless custom actions *are* used in the layout, type annotations are needed to infer `T` (here `NoCustom`).
Obviously when defaults with const generics are stabilized, this problem can be removed without any breaking changes.