### PR TITLE
Chording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Corrected HID report descriptor
 * Add max_packet_size() to HidDevice to allow differing report sizes
 * Allows default layer to be set on a Layout externally
+* Add Chording for multiple keys pressed at the same time to equal another key
 
 Breaking changes:
 * Row and Column pins are now a simple array. For the STM32 MCU, you

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,3 @@ embedded-hal = { version = "0.2", features = ["unproven"] }
 usb-device = "0.2"
 heapless = "0.7"
 arraydeque = { version = "0.4.5", default-features = false }
-bitvec = "0.20"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The supported features are:
  - Multiple keys sent on an single key press. It allows to have keys
    for complex shortcut, for example a key for copy and paste or alt tab, or
    for whatever you want.
+ - Chording multiple keys together to act as a single key
  - hold tap: different action depending if the key is held or
    tapped. For example, you can have a key acting as layer change when
    held, and space when tapped.

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -106,9 +106,7 @@ impl Chord {
                 }
                 if self.in_progress && self.keys_pressed.iter().all(|&k| !k) {
                     self.in_progress = false;
-                    for k in self.keys_pressed.iter_mut() {
-                        *k = false;
-                    }
+                    self.keys_pressed.iter_mut().for_each(|k| *k = false);
                     return Some(Event::release_from_coord(self.def.result));
                 }
             }

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -1,8 +1,38 @@
 //! Provides chord support for two keys pressed at once.
 //! E.g. Left + Right arrow at the same time => paste.
+
+/// ## Usage
+/// ``` no_run
+/// use keyberon::chording::{Chording, ChordDef};
+/// use keyberon::layout::{Layout, Event::*};
+/// use keyberon::debounce::Debouncer;
+/// use keyberon::matrix::{Matrix, PressedKeys};
+///
+/// // The chord is defined by two or more locations in the layout
+/// // that correspond to a single location in the layout
+/// const CHORD0: ChordDef = ChordDef::new((0, 2), &[(0, 0), (0, 1)]);
+/// const CHORD1: ChordDef = ChordDef::new((0, 0), &[(0, 1), (0, 2)]);
+/// const CHORDS: [ChordDef; 2] = [CHORD0, CHORD1];
+///
+/// pub static LAYERS: keyberon::layout::Layers = keyberon::layout::layout! {
+///     { [ A B C ] }
+/// };
+///
+/// let mut layout = Layout::new(LAYERS);
+/// // Debouncer period determines chording timeout
+/// let mut debouncer: Debouncer<PressedKeys<3, 1>> =
+///     Debouncer::new(PressedKeys::default(), PressedKeys::default(), 30);
+/// let mut chording = Chording::new(&CHORDS);
+///
+/// // the rest of this example should be called inside a callback
+/// // The PressedKeys are normall determined by calling the matrix
+/// let keys_pressed = PressedKeys([[true, true, false]]);
+/// let events = chording.tick(debouncer.events(keys_pressed).collect()).into_iter();
+///
+/// events.for_each(|e| layout.event(e));
+/// ```
 use crate::layout::Event;
-use bitvec::prelude::*;
-use heapless::{Vec, consts::{U16, U8, U4}};
+use heapless::Vec;
 
 type KeyPosition = (u8, u8);
 
@@ -27,7 +57,7 @@ impl ChordDef {
 pub struct Chord {
     def: &'static ChordDef,
     in_progress: bool,
-    keys_pressed: u8
+    keys_pressed: Vec<bool, 8>,
 }
 
 impl Chord {
@@ -36,43 +66,50 @@ impl Chord {
         let mut me = Self {
             def,
             in_progress: false,
-            keys_pressed: 0b000_0000,
+            keys_pressed: Vec::<bool, 8>::new(),
         };
-        me.set_high_bits(true);
+        me.in_progress = false;
+        def.keys
+            .iter()
+            .for_each(|_| me.keys_pressed.push(false).unwrap());
         me
-    }
-
-    // Set to true when looking to trigger, false for when looking to release.
-    fn set_high_bits(&mut self, value: bool) {
-        let len = self.def.keys.len();
-        self.in_progress = !value;
-        for k in 0..8 {
-            self.keys_pressed.view_bits_mut::<Msb0>().set(k, k >= len);
-        }
     }
 
     fn process(&mut self, event: Event) -> Option<Event> {
         match event {
-            e @ Event::Press(_,_) => {
+            e @ Event::Press(_, _) => {
                 if !self.in_progress {
-                    for (k, _) in self.def.keys.iter().enumerate().filter(|(_,key)| **key == e.coord()) {
-                        self.keys_pressed.view_bits_mut::<Msb0>().set(k, true);
+                    for (k, _) in self
+                        .def
+                        .keys
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, key)| **key == e.coord())
+                    {
+                        self.keys_pressed[k] = true;
                     }
-                    if self.keys_pressed.view_bits_mut::<Msb0>().all() {
-                        self.set_high_bits(false);
+                    if self.keys_pressed.iter().all(|&k| k) {
+                        self.in_progress = true;
                         return Some(Event::press_from_coord(self.def.result));
                     }
                 }
-            },
-            e @ Event::Release(_,_) => {
-                for (k,_) in self.def.keys.iter().enumerate().filter(|(_,key)| **key == e.coord()) {
-                   self.keys_pressed.view_bits_mut::<Msb0>().set(k, false);
+            }
+            e @ Event::Release(_, _) => {
+                for (k, _) in self
+                    .def
+                    .keys
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, key)| **key == e.coord())
+                {
+                    self.keys_pressed[k] = false;
                 }
-                if self.in_progress {
-                    if self.keys_pressed.view_bits_mut::<Msb0>().not_any() {
-                        self.set_high_bits(true);
-                        return Some(Event::release_from_coord(self.def.result));
+                if self.in_progress && self.keys_pressed.iter().all(|&k| !k) {
+                    self.in_progress = false;
+                    for k in self.keys_pressed.iter_mut() {
+                        *k = false;
                     }
+                    return Some(Event::release_from_coord(self.def.result));
                 }
             }
         }
@@ -83,39 +120,114 @@ impl Chord {
 /// Two keys at once!
 pub struct Chording {
     /// Defined chords
-    chords: Vec<Chord, U16>,
+    chords: Vec<Chord, 16>,
 }
 
 impl Chording {
     /// Take the predefined chord list in.
     pub fn new(chords: &'static [ChordDef]) -> Self {
-        let mut v = Vec::<Chord, U16>::new();
-        for ch in chords { v.push(Chord::new(ch)).ok().unwrap(); }
+        let mut v = Vec::<Chord, 16>::new();
+        for ch in chords {
+            v.push(Chord::new(ch)).ok().unwrap();
+        }
         Self { chords: v }
     }
 
     /// Consolidate events and return processed results as a result.
-    pub fn tick(&mut self, vec: Vec<Event, U8>) -> Vec<Event, U8> {
-        let mut vec_remove = Vec::<Event,U8>::new();
+    pub fn tick(&mut self, vec: Vec<Event, 8>) -> Vec<Event, 8> {
+        let mut vec_remove = Vec::<Event, 8>::new();
 
         // If the event is the last in a chord, map it to the result (and remove any assisting events.)
-        let events : Vec<Event, U4> = vec.into_iter().map(|event|{
-            for chord in self.chords.iter_mut() {
-                match chord.process(event) {
-                    Some(e @ Event::Press(_, _)) => {
-                        vec_remove.extend(chord.def.keys.iter().copied().map(Event::press_from_coord));
-                        return e;
-                    },
-                    Some(e @ Event::Release(_, _)) => {
-                        vec_remove.extend(chord.def.keys.iter().copied().map(Event::release_from_coord));
-                        return e;
-                    },
-                    None => {}
+        let events: Vec<Event, 4> = vec
+            .into_iter()
+            .map(|event| {
+                for chord in self.chords.iter_mut() {
+                    match chord.process(event) {
+                        Some(e @ Event::Press(_, _)) => {
+                            vec_remove.extend(
+                                chord.def.keys.iter().copied().map(Event::press_from_coord),
+                            );
+                            return e;
+                        }
+                        Some(e @ Event::Release(_, _)) => {
+                            vec_remove.extend(
+                                chord
+                                    .def
+                                    .keys
+                                    .iter()
+                                    .copied()
+                                    .map(Event::release_from_coord),
+                            );
+                            return e;
+                        }
+                        None => {}
+                    }
                 }
-            }
-            event
-        }).collect();
+                event
+            })
+            .collect();
 
-        events.into_iter().filter(|event| !vec_remove.contains(event)).collect()
+        events
+            .into_iter()
+            .filter(|event| !vec_remove.contains(event))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{ChordDef, Chording};
+    use crate::layout::{Event, Event::*};
+    use heapless::Vec;
+
+    #[test]
+    fn single_press_release() {
+        const CHORD: ChordDef = ChordDef::new((0, 2), &[(0, 0), (0, 1)]);
+        let mut chording = Chording::new(&[CHORD]);
+
+        // Verify a single press goes through chording unchanged
+        let mut single_press = Vec::<Event, 8>::new();
+        single_press.push(Press(0, 0)).ok();
+        assert_eq!(chording.tick(single_press), &[Press(0, 0)]);
+        let mut single_release = Vec::<Event, 8>::new();
+        single_release.push(Release(0, 0)).ok();
+        assert_eq!(chording.tick(single_release), &[Release(0, 0)]);
+    }
+
+    #[test]
+    fn chord_press_release() {
+        const CHORD: ChordDef = ChordDef::new((0, 2), &[(0, 0), (0, 1)]);
+        let mut chording = Chording::new(&[CHORD]);
+
+        // Verify a chord is converted to the correct key
+        let mut double_press = Vec::<Event, 8>::new();
+        double_press.push(Press(0, 0)).ok();
+        double_press.push(Press(0, 1)).ok();
+        assert_eq!(chording.tick(double_press), &[Press(0, 2)]);
+        let mut double_release = Vec::<Event, 8>::new();
+        double_release.push(Release(0, 0)).ok();
+        double_release.push(Release(0, 1)).ok();
+        let chord_double_release = chording.tick(double_release);
+        assert_eq!(chord_double_release, &[Release(0, 2)]);
+    }
+
+    #[test]
+    fn chord_press_half_release() {
+        const CHORD: ChordDef = ChordDef::new((0, 2), &[(0, 0), (0, 1)]);
+        let mut chording = Chording::new(&[CHORD]);
+
+        // Verify a chord is converted to the correct key
+        let mut double_press = Vec::<Event, 8>::new();
+        double_press.push(Press(0, 0)).ok();
+        double_press.push(Press(0, 1)).ok();
+        assert_eq!(chording.tick(double_press), &[Press(0, 2)]);
+        let mut first_release = Vec::<Event, 8>::new();
+        first_release.push(Release(0, 0)).ok();
+        // we will see the key release pass through, but this won't matter
+        assert_eq!(chording.tick(first_release), &[Release(0, 0)]);
+        let mut second_release = Vec::<Event, 8>::new();
+        second_release.push(Release(0, 1)).ok();
+        // once all keys of the combo are released, the combo is released
+        assert_eq!(chording.tick(second_release), &[Release(0, 2)]);
     }
 }

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -1,3 +1,5 @@
+//! Chording implemention to mimic a single key.
+//!
 //! Provides chord support for emulating a single layout event
 //! from multiple key presses. The single event press is triggered
 //! once all the keys of the chord have been pressed and the chord
@@ -24,6 +26,7 @@
 ///     ((0, 2), &[(0, 0), (0, 1)]),
 ///     ((0, 0), &[(0, 1), (0, 2)]),
 /// ];
+/// // A count of 30 (ms) is a good default
 /// const DEBOUNCE_COUNT: u16 = 30;
 ///
 /// pub static LAYERS: keyberon::layout::Layers = keyberon::layout::layout! {
@@ -83,7 +86,7 @@ impl Chord {
         me
     }
 
-    fn tick(&mut self, events: &Vec<Event, 8>) {
+    fn tick(&mut self, events: &[Event]) {
         for e in events {
             for (k, _) in self
                 .def
@@ -97,7 +100,7 @@ impl Chord {
         }
     }
 
-    fn contains_chord(&mut self, events: &Vec<Event, 8>) -> bool {
+    fn contains_chord(&mut self, events: &[Event]) -> bool {
         for key in self.def.1 {
             if events
                 .iter()
@@ -145,7 +148,8 @@ impl Chord {
     }
 }
 
-/// Two keys at once!
+/// The chording manager. Initialize with a list of chord
+/// definitions, and update after debounce
 pub struct Chording<const N: usize> {
     /// Defined chords
     chords: Vec<Chord, N>,
@@ -154,11 +158,9 @@ pub struct Chording<const N: usize> {
 impl<const N: usize> Chording<N> {
     /// Take the predefined chord list in.
     pub fn new(chords: &'static [ChordDef; N]) -> Self {
-        let mut v = Vec::<Chord, N>::new();
-        for ch in chords {
-            v.push(Chord::new(ch)).ok().unwrap();
+        Self {
+            chords: chords.iter().map(Chord::new).collect(),
         }
-        Self { chords: v }
     }
 
     /// Consolidate events and return processed results as a result.

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -218,6 +218,22 @@ mod test {
     }
 
     #[test]
+    fn chord_individual_press() {
+        const CHORDS: [ChordDef; 1] = [((0, 2), &[(0, 0), (0, 1)])];
+        let mut chording = Chording::new(&CHORDS);
+
+        // Verify that pressing the keys that make up a chord at different
+        // times will not trigger the chord
+        let mut key_a_press = Vec::<Event, 8>::new();
+        key_a_press.push(Press(0, 0)).ok();
+        assert_eq!(chording.tick(key_a_press), &[Press(0, 0)]);
+        let mut key_b_press = Vec::<Event, 8>::new();
+        key_b_press.push(Press(0, 1)).ok();
+        assert_eq!(chording.tick(key_b_press), &[Press(0, 1)]);
+        let nothing = Vec::<Event, 8>::new();
+        assert_eq!(chording.tick(nothing), &[]);
+    }
+    #[test]
     fn chord_press_half_release() {
         const CHORDS: [ChordDef; 1] = [((0, 2), &[(0, 0), (0, 1)])];
         let mut chording = Chording::new(&CHORDS);

--- a/src/chording.rs
+++ b/src/chording.rs
@@ -262,5 +262,22 @@ mod test {
         double_release.push(Release(0, 0)).ok();
         double_release.push(Release(0, 1)).ok();
         assert_eq!(chording.tick(double_release), &[Release(1, 1)]);
+
+        // If a three key chord has not been fully released, the released keys
+        // that form another chord should still work to press and release the
+        // two key chord
+        let mut triple_press = Vec::<Event, 8>::new();
+        triple_press.push(Press(0, 0)).ok();
+        triple_press.push(Press(0, 1)).ok();
+        triple_press.push(Press(0, 2)).ok();
+        assert_eq!(chording.tick(triple_press), &[Press(1, 0)]);
+        let mut half_triple_release = Vec::<Event, 8>::new();
+        half_triple_release.push(Release(0, 1)).ok();
+        half_triple_release.push(Release(0, 2)).ok();
+        assert_eq!(chording.tick(half_triple_release), &[]);
+        let mut double_press = Vec::<Event, 8>::new();
+        double_press.push(Press(0, 1)).ok();
+        double_press.push(Press(0, 2)).ok();
+        assert_eq!(chording.tick(double_press), &[Press(1, 2)]);
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -91,16 +91,6 @@ impl Event {
         }
     }
 
-    /// Creats a push event from co-ordinates
-    pub fn press_from_coord((i, j): (u8, u8)) -> Event {
-        Event::Press(i, j)
-    }
-
-    /// Creats a release event from co-ordinates
-    pub fn release_from_coord((i, j): (u8, u8)) -> Event {
-        Event::Release(i, j)
-    }
-
     /// Transforms the coordinates of the event.
     ///
     /// # Example


### PR DESCRIPTION
This PR is an alternative to #31 using heapless::Vec instead of adding a dependency on [bitvec](https://github.com/bitvecto-rs/bitvec). If binary size is a major concern, the code could be adapted to use core::ops:BitOr and similar methods to operate on a `u8` instead of an iterator of `bool`s.

Doc example and tests added for ease of use. Tested at this [commit](https://github.com/camrbuss/pinci/blob/f71fabe251b5245cadc1c8bdbf87d1f3e3c7dc63/firmware/src/main.rs) on pinci keyboard.

Shout out to @gilescope for most of the work!