### PR TITLE
Implement custom handling for HoldTap actions.

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -37,8 +37,10 @@ pub enum HoldTapConfig {
     /// The return value should be the intended action that should be used. A
     /// [Some] value will cause one of: [WaitingAction::Tap] for the configured
     /// tap action, [WaitingAction::Hold] for the hold action, and
-    /// [WaitingAction::NoOp] to force no action to occur this cycle. A [None]
-    /// value will cause a fallback to the timeout-based approach.
+    /// [WaitingAction::NoOp] to drop handling of the key press. A [None]
+    /// value will cause a fallback to the timeout-based approach. If the
+    /// timeout is not triggered, the next tick will call the custom handler
+    /// again.
     ///
     /// # Example:
     /// Hold events can be prevented from triggering when pressing multiple keys

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,27 +1,22 @@
 //! The different actions that can be done.
 
 use crate::key_code::KeyCode;
-use crate::layout::{Stack, WaitingAction};
+use crate::layout::{WaitingAction, StackedIter};
 use core::fmt::Debug;
 
 /// A newtype around a custom handler for HoldTap actions.
 #[derive(Copy, Clone)]
-pub struct CustomHandler(pub &'static (dyn Fn(&Stack) -> Option<WaitingAction> + Sync));
+pub struct CustomHandler(pub fn(StackedIter) -> Option<WaitingAction>);
 
 impl Debug for CustomHandler {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Custom").field(&"<function>").finish()
+        Debug::fmt(&(self.0 as fn(StackedIter<'static>) -> Option<WaitingAction>), f)
     }
 }
 
 impl PartialEq for CustomHandler {
     fn eq(&self, other: &Self) -> bool {
-        // Only compare the thin pointer for equality, since fat pointers can
-        // fail equality comparisons.
-        core::ptr::eq(
-            self.0 as *const _ as *const (),
-            other.0 as *const _ as *const (),
-        )
+        self.0 as fn(StackedIter<'static>) -> Option<WaitingAction> == other.0
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -220,7 +220,7 @@ struct WaitingState<T: 'static> {
 }
 
 /// Actions that can be triggered for a key configured for HoldTap.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WaitingAction {
     /// Trigger the holding event.
     Hold,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -816,7 +816,6 @@ mod test {
     #[test]
     fn custom_handler() {
         fn always_tap(_: StackedIter) -> Option<WaitingAction> {
-            std::println!("hit!");
             Some(WaitingAction::Tap)
         }
         fn always_hold(_: StackedIter) -> Option<WaitingAction> {
@@ -828,7 +827,6 @@ mod test {
         fn always_none(_: StackedIter) -> Option<WaitingAction> {
             None
         }
-        std::println!("Assigning layers");
         static LAYERS: Layers<4, 1, 1> = [[[
             HoldTap {
                 timeout: 200,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -252,7 +252,7 @@ impl<T> WaitingState<T> {
                 }
             }
             HoldTapConfig::Custom(func) => {
-                if let Some(waiting_action) = (func.0)(StackedIter(stacked.iter())) {
+                if let Some(waiting_action) = (func)(StackedIter(stacked.iter())) {
                     return waiting_action;
                 }
             }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -26,7 +26,7 @@ where
     R: OutputPin,
 {
     /// Creates a new Matrix.
-    /// 
+    ///
     /// Assumes columns are pull-up inputs,
     /// and rows are output pins which are set high when not being scanned.
     pub fn new<E>(cols: [C; CS], rows: [R; RS]) -> Result<Self, E>


### PR DESCRIPTION
Allows an API user to control the behavior of the HoldTap action
however they prefer. This allows behaviors like preventing hold
actions when rolling keys on the same side of a split keyboard.

Fixes #35