### PR TITLE
Add missing comma in layout! macro

### DIFF
--- a/keyberon-macros/src/lib.rs
+++ b/keyberon-macros/src/lib.rs
@@ -109,7 +109,7 @@ fn parse_keycode_group(input: TokenStream, out: &mut TokenStream) {
             TokenTree::Group(g) => parse_group(&g, &mut inner),
         }
     }
-    out.extend(quote! { keyberon::action::Action::MultipleActions(&[#inner]) });
+    out.extend(quote! { keyberon::action::Action::MultipleActions(&[#inner]), });
 }
 
 fn punctuation_to_keycode(p: &Punct, out: &mut TokenStream) {

--- a/keyberon-macros/tests/mod.rs
+++ b/keyberon-macros/tests/mod.rs
@@ -97,3 +97,14 @@ fn test_escapes() {
     static B: Layers<2, 1, 1> = [[[k(Bslash), k(Quote)]]];
     assert_eq!(A, B);
 }
+
+#[test]
+fn test_keycode_group_comma() {
+    static A: Layers<3, 1, 1> = layout! {
+        {
+            [ C [D E] F ]
+        }
+    };
+    static B: Layers<3, 1, 1> = [[[k(C), Action::MultipleActions(&[k(D), k(E)]), k(F)]]];
+    assert_eq!(A, B);
+}


### PR DESCRIPTION
The missing comma was causing a compile time error if a keycode group was placed somewhere else than at the end of a row.

This is a simple patch.
