### PR TITLE
Add Cantor keyboard to KEYOARDS.md

### DIFF
--- a/KEYBOARDS.md
+++ b/KEYBOARDS.md
@@ -14,4 +14,4 @@
 | [makerdiary M60](https://github.com/jamesmunns/m60-keyboard/)              | PCB              | nRF52840  | <ul><li>[x] Matrix </li><li>[x] RGB LEDs</li> |
 | [PouetPouet](https://github.com/dkm/pouetpouet-board)                          | PCB              | STM32F072 | <ul><li>[x] Matrix </li></ul>                                                |
 | [corne](https://github.com/simmsb/keyboard)                                | PCB              | nRF52840  | <ul><li>[x] Matrix </li><li>[x] RGB LEDs</li><li>[x] OLED</li><li>[x] split</li></ul>          |
-| [cantor](https://github.com/dariogoetz/cantor-firmware-keyberon)           | PCB              | STM32F401 | <ul><li>[x] Matrix </li><li>[ ] LEDs</li><li>[x] Split</li><li>[x] Diodeless</li></ul>         |
+| [Cantor](https://github.com/dariogoetz/cantor-firmware-keyberon)           | PCB              | STM32F401 | <ul><li>[x] Matrix </li><li>[ ] LEDs</li><li>[x] Split</li><li>[x] Diodeless</li></ul>         |


### PR DESCRIPTION
I've recently written firmware for the [Cantor](https://github.com/diepala/cantor) keyboard using keyberon and rtic. The Cantor is a diodeless keyboard, so it adds something new to the mix. I would like to add it here.