### PR TITLE
Add DirectPinMatrix for diodeless keyboards

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -71,3 +71,50 @@ where
         Ok(keys)
     }
 }
+
+/// Matrix-representation of switches directly attached to the pins ("diodeless").
+///
+/// Generic parameters are in order: The type of column pins,
+/// the number of columns and rows.
+pub struct DirectPinMatrix<P, const CS: usize, const RS: usize>
+where
+    P: InputPin,
+{
+    pins: [[Option<P>; CS]; RS],
+}
+
+impl<P, const CS: usize, const RS: usize> DirectPinMatrix<P, CS, RS>
+where
+    P: InputPin,
+{
+    /// Creates a new DirectPinMatrix.
+    ///
+    /// Assumes pins are pull-up inputs. Spots in the matrix that are
+    /// not corresponding to any pins use ´None´.
+    pub fn new<E>(pins: [[Option<P>; CS]; RS]) -> Result<Self, E>
+    where
+        P: InputPin<Error = E>,
+    {
+        let res = Self { pins };
+        Ok(res)
+    }
+
+    /// Scans the pins and checks which keys are pressed (state is "low").
+    pub fn get<E>(&mut self) -> Result<[[bool; CS]; RS], E>
+    where
+        P: InputPin<Error = E>,
+    {
+        let mut keys = [[false; CS]; RS];
+
+        for (ri, row) in (&mut self.pins).iter_mut().enumerate() {
+            for (ci, col_option) in row.iter().enumerate() {
+                if let Some(col) = col_option {
+                    if col.is_low()? {
+                        keys[ri][ci] = true;
+                    }
+                }
+            }
+        }
+        Ok(keys)
+    }
+}


### PR DESCRIPTION
I used a ´DirectPinMatrix´ for my firmware for the Cantor. It assumes that each switch is directly attached to an individual pin instead of using a row/column matrix.

I thought, I'd offer the code as it may be of interest for others, too.