### PR TITLE
Expose Layout::current_layer as public method

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -512,7 +512,7 @@ impl<const C: usize, const R: usize, const L: usize, T: 'static> Layout<C, R, L,
     }
 
     /// Obtain the index of the current active layer
-    fn current_layer(&self) -> usize {
+    pub fn current_layer(&self) -> usize {
         self.states
             .iter()
             .rev()


### PR DESCRIPTION
This makes `current_layer` public again (was made private in https://github.com/TeXitoi/keyberon/commit/5e2ae6e59db9ff75668ec93046ae4a57385813c3). Having this method public is useful to e.g. change LED colors based on layer. 