### PR TITLE
Reduce layout size by using reference in Action::HoldTap variant

### DIFF
--- a/keyberon-macros/src/lib.rs
+++ b/keyberon-macros/src/lib.rs
@@ -109,7 +109,7 @@ fn parse_keycode_group(input: TokenStream, out: &mut TokenStream) {
             TokenTree::Group(g) => parse_group(&g, &mut inner),
         }
     }
-    out.extend(quote! { keyberon::action::Action::MultipleActions(&[#inner]), });
+    out.extend(quote! { keyberon::action::Action::MultipleActions(&[#inner].as_slice()), });
 }
 
 fn punctuation_to_keycode(p: &Punct, out: &mut TokenStream) {
@@ -123,21 +123,21 @@ fn punctuation_to_keycode(p: &Punct, out: &mut TokenStream) {
         '/' => out.extend(quote! { keyberon::action::Action::KeyCode(keyberon::key_code::KeyCode::Slash), }),
 
         // Shifted punctuation
-        '!' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb1]), }),
-        '@' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb2]), }),
-        '#' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb3]), }),
-        '$' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb4]), }),
-        '%' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb5]), }),
-        '^' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb6]), }),
-        '&' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb7]), }),
-        '*' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb8]), }),
-        '_' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Minus]), }),
-        '+' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Equal]), }),
-        '|' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Bslash]), }),
-        '~' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Grave]), }),
-        '<' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Comma]), }),
-        '>' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Dot]), }),
-        '?' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Slash]), }),
+        '!' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb1].as_slice()), }),
+        '@' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb2].as_slice()), }),
+        '#' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb3].as_slice()), }),
+        '$' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb4].as_slice()), }),
+        '%' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb5].as_slice()), }),
+        '^' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb6].as_slice()), }),
+        '&' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb7].as_slice()), }),
+        '*' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb8].as_slice()), }),
+        '_' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Minus].as_slice()), }),
+        '+' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Equal].as_slice()), }),
+        '|' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Bslash].as_slice()), }),
+        '~' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Grave].as_slice()), }),
+        '<' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Comma].as_slice()), }),
+        '>' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Dot].as_slice()), }),
+        '?' => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Slash].as_slice()), }),
         // Is this reachable?
         _ => emit_error!(p, "Punctuation could not be parsed as a keycode")
     }
@@ -164,12 +164,12 @@ fn literal_to_keycode(l: &Literal, out: &mut TokenStream) {
         "'['" => out.extend(quote! { keyberon::action::Action::KeyCode(keyberon::key_code::KeyCode::LBracket), }),
         "']'" => out.extend(quote! { keyberon::action::Action::KeyCode(keyberon::key_code::KeyCode::RBracket), }),
         "'`'" => out.extend(quote! { keyberon::action::Action::KeyCode(keyberon::key_code::KeyCode::Grave), }),
-        "'\"'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Quote]), }),
-        "'('" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb9]), }),
-        "')'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb0]), }),
-        "'{'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::LBracket]), }),
-        "'}'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::RBracket]), }),
-        "'_'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Minus]), }),
+        "'\"'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Quote].as_slice()), }),
+        "'('" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb9].as_slice()), }),
+        "')'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Kb0].as_slice()), }),
+        "'{'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::LBracket].as_slice()), }),
+        "'}'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::RBracket].as_slice()), }),
+        "'_'" => out.extend(quote! { keyberon::action::Action::MultipleKeyCodes(&[keyberon::key_code::KeyCode::LShift, keyberon::key_code::KeyCode::Minus].as_slice()), }),
 
         s if s.starts_with('\'') => emit_error!(l, "Literal could not be parsed as a keycode"; help = "Maybe try without quotes?"),
 

--- a/keyberon-macros/tests/mod.rs
+++ b/keyberon-macros/tests/mod.rs
@@ -8,7 +8,7 @@ use keyberon_macros::layout;
 fn test_layout_equality() {
     macro_rules! s {
         ($k:expr) => {
-            m(&[LShift, $k])
+            m(&[LShift, $k].as_slice())
         };
     }
 
@@ -30,7 +30,7 @@ fn test_layout_equality() {
         ],
         [
             [k(Tab),    k(Kb1), k(Kb2), k(Kb3), k(Kb4), k(Kb5),   k(Kb6),  k(Kb7),  k(Kb8), k(Kb9), k(Kb0), k(BSpace)],
-            [k(LCtrl),  s!(Kb1), s!(Kb2), s!(Kb3), s!(Kb4), s!(Kb5),   s!(Kb6), s!(Kb7), s!(Kb8),  s!(Kb9), s!(Kb0), MultipleActions(&[k(LCtrl), k(Grave)])],
+            [k(LCtrl),  s!(Kb1), s!(Kb2), s!(Kb3), s!(Kb4), s!(Kb5),   s!(Kb6), s!(Kb7), s!(Kb8),  s!(Kb9), s!(Kb0), MultipleActions(&[k(LCtrl), k(Grave)].as_slice())],
             [k(LShift), NoOp, NoOp, NoOp, NoOp, NoOp,   k(Left), k(Down), k(Up), k(Right), NoOp, s!(Grave)],
             [NoOp, NoOp, k(LGui), Trans, Trans, Trans,   Trans, Trans, Trans, k(RAlt), NoOp, NoOp],
         ],
@@ -65,7 +65,7 @@ fn test_nesting() {
     };
     static B: Layers<2, 1, 1> = [[[
         k(D),
-        Action::MultipleActions(&[Action::Layer(5), Action::MultipleActions(&[k(C), k(D)])]),
+        Action::MultipleActions(&[Action::Layer(5), Action::MultipleActions(&[k(C), k(D)].as_slice())].as_slice()),
     ]]];
     assert_eq!(A, B);
 }
@@ -105,6 +105,6 @@ fn test_keycode_group_comma() {
             [ C [D E] F ]
         }
     };
-    static B: Layers<3, 1, 1> = [[[k(C), Action::MultipleActions(&[k(D), k(E)]), k(F)]]];
+    static B: Layers<3, 1, 1> = [[[k(C), Action::MultipleActions(&[k(D), k(E)].as_slice()), k(F)]]];
     assert_eq!(A, B);
 }

--- a/keyberon-macros/tests/mod.rs
+++ b/keyberon-macros/tests/mod.rs
@@ -14,8 +14,8 @@ fn test_layout_equality() {
 
     static S_ENTER: Action = Action::HoldTap(&HoldTapAction {
         timeout: 280,
-        hold: &Action::KeyCode(RShift),
-        tap: &Action::KeyCode(Enter),
+        hold: Action::KeyCode(RShift),
+        tap: Action::KeyCode(Enter),
         config: HoldTapConfig::PermissiveHold,
         tap_hold_interval: 0,
     });

--- a/keyberon-macros/tests/mod.rs
+++ b/keyberon-macros/tests/mod.rs
@@ -1,5 +1,5 @@
 extern crate keyberon_macros;
-use keyberon::action::{k, l, m, Action, Action::*, HoldTapConfig};
+use keyberon::action::{k, l, m, Action, Action::*, HoldTapConfig, HoldTapAction};
 use keyberon::key_code::KeyCode::*;
 use keyberon::layout::*;
 use keyberon_macros::layout;
@@ -12,13 +12,13 @@ fn test_layout_equality() {
         };
     }
 
-    static S_ENTER: Action = Action::HoldTap {
+    static S_ENTER: Action = Action::HoldTap(&HoldTapAction {
         timeout: 280,
         hold: &Action::KeyCode(RShift),
         tap: &Action::KeyCode(Enter),
         config: HoldTapConfig::PermissiveHold,
         tap_hold_interval: 0,
-    };
+    });
 
     #[rustfmt::skip]
     pub static LAYERS_OLD: Layers<12, 4, 2> = [

--- a/src/action.rs
+++ b/src/action.rs
@@ -73,8 +73,8 @@ pub enum HoldTapConfig {
     /// // not be triggered when pressing Tab-T, CapsLock-G, nor Shift-B.
     /// const A_SHIFT: Action = Action::HoldTap(&HoldTapAction {
     ///     timeout: 200,
-    ///     hold: &Action::KeyCode(KeyCode::LShift),
-    ///     tap: &Action::KeyCode(KeyCode::A),
+    ///     hold: Action::KeyCode(KeyCode::LShift),
+    ///     tap: Action::KeyCode(KeyCode::A),
     ///     config: HoldTapConfig::Custom(left_mod),
     ///     tap_hold_interval: 0,
     /// });
@@ -83,8 +83,8 @@ pub enum HoldTapConfig {
     /// // not be triggered when pressing Y-Pipe, H-Enter, nor N-Shift.
     /// const SEMI_SHIFT: Action = Action::HoldTap(&HoldTapAction {
     ///     timeout: 200,
-    ///     hold: &Action::KeyCode(KeyCode::RShift),
-    ///     tap: &Action::KeyCode(KeyCode::SColon),
+    ///     hold: Action::KeyCode(KeyCode::RShift),
+    ///     tap: Action::KeyCode(KeyCode::SColon),
     ///     config: HoldTapConfig::Custom(right_mod),
     ///     tap_hold_interval: 0,
     /// });
@@ -145,9 +145,9 @@ where
     /// difference between a hold and a tap.
     pub timeout: u16,
     /// The hold action.
-    pub hold: &'static Action<T>,
+    pub hold: Action<T>,
     /// The tap action.
-    pub tap: &'static Action<T>,
+    pub tap: Action<T>,
     /// Behavior configuration.
     pub config: HoldTapConfig,
     /// Configuration of the tap and hold holds the tap action.

--- a/src/action.rs
+++ b/src/action.rs
@@ -135,7 +135,6 @@ impl Eq for HoldTapConfig {}
 /// but whatever the configuration is, if the key is pressed more
 /// than `timeout`, the hold action is activated (if no other
 /// action was determined before).
-#[doc(inline)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct HoldTapAction<T>
 where

--- a/src/action.rs
+++ b/src/action.rs
@@ -245,3 +245,15 @@ pub const fn d<T>(layer: usize) -> Action<T> {
 pub const fn m<T>(kcs: &'static [KeyCode]) -> Action<T> {
     Action::MultipleKeyCodes(kcs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem;
+
+    #[test]
+    fn size_of_action() {
+        const PTR_SIZE: usize = mem::size_of::<&()>();
+        assert_eq!(mem::size_of::<Action::<()>>(), 3 * PTR_SIZE);
+    }
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -185,9 +185,9 @@ where
     /// Multiple key codes sent at the same time, as if these keys
     /// were pressed at the same time. Useful to send a shifted key,
     /// or complex shortcuts like Ctrl+Alt+Del in a single key press.
-    MultipleKeyCodes(&'static [KeyCode]),
+    MultipleKeyCodes(&'static &'static [KeyCode]),
     /// Multiple actions sent at the same time.
-    MultipleActions(&'static [Action<T>]),
+    MultipleActions(&'static &'static [Action<T>]),
     /// While pressed, change the current layer. That's the classic
     /// Fn key. If several layer actions are hold at the same time,
     /// the last pressed defines the current layer.
@@ -242,7 +242,7 @@ pub const fn d<T>(layer: usize) -> Action<T> {
 
 /// A shortcut to create a `Action::MultipleKeyCodes`, useful to
 /// create compact layout.
-pub const fn m<T>(kcs: &'static [KeyCode]) -> Action<T> {
+pub const fn m<T>(kcs: &'static &'static [KeyCode]) -> Action<T> {
     Action::MultipleKeyCodes(kcs)
 }
 
@@ -254,6 +254,6 @@ mod tests {
     #[test]
     fn size_of_action() {
         const PTR_SIZE: usize = mem::size_of::<&()>();
-        assert_eq!(mem::size_of::<Action::<()>>(), 3 * PTR_SIZE);
+        assert_eq!(mem::size_of::<Action::<()>>(), 2 * PTR_SIZE);
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -46,7 +46,7 @@
 /// ```
 pub use keyberon_macros::*;
 
-use crate::action::{Action, HoldTapConfig};
+use crate::action::{Action, HoldTapConfig, HoldTapAction};
 use crate::key_code::KeyCode;
 use arraydeque::ArrayDeque;
 use heapless::Vec;
@@ -447,13 +447,13 @@ impl<const C: usize, const R: usize, const L: usize, T: 'static> Layout<C, R, L,
         use Action::*;
         match action {
             NoOp | Trans => (),
-            HoldTap {
+            HoldTap(HoldTapAction {
                 timeout,
                 hold,
                 tap,
                 config,
                 tap_hold_interval,
-            } => {
+            }) => {
                 if *tap_hold_interval == 0
                     || coord != self.tap_hold_tracker.coord
                     || self.tap_hold_tracker.timeout == 0
@@ -550,20 +550,20 @@ mod test {
     fn basic_hold_tap() {
         static LAYERS: Layers<2, 1, 2> = [
             [[
-                HoldTap {
+                HoldTap(&HoldTapAction {
                     timeout: 200,
                     hold: &l(1),
                     tap: &k(Space),
                     config: HoldTapConfig::Default,
                     tap_hold_interval: 0,
-                },
-                HoldTap {
+                }),
+                HoldTap(&HoldTapAction {
                     timeout: 200,
                     hold: &k(LCtrl),
                     tap: &k(Enter),
                     config: HoldTapConfig::Default,
                     tap_hold_interval: 0,
-                },
+                }),
             ]],
             [[Trans, m(&[LCtrl, Enter])]],
         ];
@@ -599,20 +599,20 @@ mod test {
     #[test]
     fn hold_tap_interleaved_timeout() {
         static LAYERS: Layers<2, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(LAlt),
                 tap: &k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 0,
-            },
-            HoldTap {
+            }),
+            HoldTap(&HoldTapAction {
                 timeout: 20,
                 hold: &k(LCtrl),
                 tap: &k(Enter),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 0,
-            },
+            }),
         ]]];
         let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -646,13 +646,13 @@ mod test {
     #[test]
     fn hold_on_press() {
         static LAYERS: Layers<2, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(LAlt),
                 tap: &k(Space),
                 config: HoldTapConfig::HoldOnOtherKeyPress,
                 tap_hold_interval: 0,
-            },
+            }),
             k(Enter),
         ]]];
         let mut layout = Layout::new(&LAYERS);
@@ -703,13 +703,13 @@ mod test {
     #[test]
     fn permissive_hold() {
         static LAYERS: Layers<2, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(LAlt),
                 tap: &k(Space),
                 config: HoldTapConfig::PermissiveHold,
                 tap_hold_interval: 0,
-            },
+            }),
             k(Enter),
         ]]];
         let mut layout = Layout::new(&LAYERS);
@@ -862,34 +862,34 @@ mod test {
             None
         }
         static LAYERS: Layers<4, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(Kb1),
                 tap: &k(Kb0),
                 config: HoldTapConfig::Custom(always_tap),
                 tap_hold_interval: 0,
-            },
-            HoldTap {
+            }),
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(Kb3),
                 tap: &k(Kb2),
                 config: HoldTapConfig::Custom(always_hold),
                 tap_hold_interval: 0,
-            },
-            HoldTap {
+            }),
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(Kb5),
                 tap: &k(Kb4),
                 config: HoldTapConfig::Custom(always_nop),
                 tap_hold_interval: 0,
-            },
-            HoldTap {
+            }),
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(Kb7),
                 tap: &k(Kb6),
                 config: HoldTapConfig::Custom(always_none),
                 tap_hold_interval: 0,
-            },
+            }),
         ]]];
         let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -955,13 +955,13 @@ mod test {
     #[test]
     fn tap_hold_interval() {
         static LAYERS: Layers<2, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(LAlt),
                 tap: &k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
-            },
+            }),
             k(Enter),
         ]]];
         let mut layout = Layout::new(&LAYERS);
@@ -1009,21 +1009,21 @@ mod test {
     #[test]
     fn tap_hold_interval_interleave() {
         static LAYERS: Layers<3, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(LAlt),
                 tap: &k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
-            },
+            }),
             k(Enter),
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(LAlt),
                 tap: &k(Enter),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
-            },
+            }),
         ]]];
         let mut layout = Layout::new(&LAYERS);
 
@@ -1129,13 +1129,13 @@ mod test {
 
     #[test]
     fn tap_hold_interval_short_hold() {
-        static LAYERS: Layers<1, 1, 1> = [[[HoldTap {
+        static LAYERS: Layers<1, 1, 1> = [[[HoldTap(&HoldTapAction {
             timeout: 50,
             hold: &k(LAlt),
             tap: &k(Space),
             config: HoldTapConfig::Default,
             tap_hold_interval: 200,
-        }]]];
+        })]]];
         let mut layout = Layout::new(&LAYERS);
 
         // press and hold the HT key, expect hold action
@@ -1171,20 +1171,20 @@ mod test {
     #[test]
     fn tap_hold_interval_different_hold() {
         static LAYERS: Layers<2, 1, 1> = [[[
-            HoldTap {
+            HoldTap(&HoldTapAction {
                 timeout: 50,
                 hold: &k(LAlt),
                 tap: &k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
-            },
-            HoldTap {
+            }),
+            HoldTap(&HoldTapAction {
                 timeout: 200,
                 hold: &k(RAlt),
                 tap: &k(Enter),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
-            },
+            }),
         ]]];
         let mut layout = Layout::new(&LAYERS);
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -552,15 +552,15 @@ mod test {
             [[
                 HoldTap(&HoldTapAction {
                     timeout: 200,
-                    hold: &l(1),
-                    tap: &k(Space),
+                    hold: l(1),
+                    tap: k(Space),
                     config: HoldTapConfig::Default,
                     tap_hold_interval: 0,
                 }),
                 HoldTap(&HoldTapAction {
                     timeout: 200,
-                    hold: &k(LCtrl),
-                    tap: &k(Enter),
+                    hold: k(LCtrl),
+                    tap: k(Enter),
                     config: HoldTapConfig::Default,
                     tap_hold_interval: 0,
                 }),
@@ -601,15 +601,15 @@ mod test {
         static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(LAlt),
-                tap: &k(Space),
+                hold: k(LAlt),
+                tap: k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 0,
             }),
             HoldTap(&HoldTapAction {
                 timeout: 20,
-                hold: &k(LCtrl),
-                tap: &k(Enter),
+                hold: k(LCtrl),
+                tap: k(Enter),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 0,
             }),
@@ -648,8 +648,8 @@ mod test {
         static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(LAlt),
-                tap: &k(Space),
+                hold: k(LAlt),
+                tap: k(Space),
                 config: HoldTapConfig::HoldOnOtherKeyPress,
                 tap_hold_interval: 0,
             }),
@@ -705,8 +705,8 @@ mod test {
         static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(LAlt),
-                tap: &k(Space),
+                hold: k(LAlt),
+                tap: k(Space),
                 config: HoldTapConfig::PermissiveHold,
                 tap_hold_interval: 0,
             }),
@@ -864,29 +864,29 @@ mod test {
         static LAYERS: Layers<4, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(Kb1),
-                tap: &k(Kb0),
+                hold: k(Kb1),
+                tap: k(Kb0),
                 config: HoldTapConfig::Custom(always_tap),
                 tap_hold_interval: 0,
             }),
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(Kb3),
-                tap: &k(Kb2),
+                hold: k(Kb3),
+                tap: k(Kb2),
                 config: HoldTapConfig::Custom(always_hold),
                 tap_hold_interval: 0,
             }),
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(Kb5),
-                tap: &k(Kb4),
+                hold: k(Kb5),
+                tap: k(Kb4),
                 config: HoldTapConfig::Custom(always_nop),
                 tap_hold_interval: 0,
             }),
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(Kb7),
-                tap: &k(Kb6),
+                hold: k(Kb7),
+                tap: k(Kb6),
                 config: HoldTapConfig::Custom(always_none),
                 tap_hold_interval: 0,
             }),
@@ -957,8 +957,8 @@ mod test {
         static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(LAlt),
-                tap: &k(Space),
+                hold: k(LAlt),
+                tap: k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
             }),
@@ -1011,16 +1011,16 @@ mod test {
         static LAYERS: Layers<3, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(LAlt),
-                tap: &k(Space),
+                hold: k(LAlt),
+                tap: k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
             }),
             k(Enter),
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(LAlt),
-                tap: &k(Enter),
+                hold: k(LAlt),
+                tap: k(Enter),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
             }),
@@ -1131,8 +1131,8 @@ mod test {
     fn tap_hold_interval_short_hold() {
         static LAYERS: Layers<1, 1, 1> = [[[HoldTap(&HoldTapAction {
             timeout: 50,
-            hold: &k(LAlt),
-            tap: &k(Space),
+            hold: k(LAlt),
+            tap: k(Space),
             config: HoldTapConfig::Default,
             tap_hold_interval: 200,
         })]]];
@@ -1173,15 +1173,15 @@ mod test {
         static LAYERS: Layers<2, 1, 1> = [[[
             HoldTap(&HoldTapAction {
                 timeout: 50,
-                hold: &k(LAlt),
-                tap: &k(Space),
+                hold: k(LAlt),
+                tap: k(Space),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
             }),
             HoldTap(&HoldTapAction {
                 timeout: 200,
-                hold: &k(RAlt),
-                tap: &k(Enter),
+                hold: k(RAlt),
+                tap: k(Enter),
                 config: HoldTapConfig::Default,
                 tap_hold_interval: 200,
             }),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -481,14 +481,14 @@ impl<const C: usize, const R: usize, const L: usize, T: 'static> Layout<C, R, L,
             }
             &MultipleKeyCodes(v) => {
                 self.tap_hold_tracker.coord = coord;
-                for &keycode in v {
+                for &keycode in *v {
                     let _ = self.states.push(NormalKey { coord, keycode });
                 }
             }
             &MultipleActions(v) => {
                 self.tap_hold_tracker.coord = coord;
                 let mut custom = CustomEvent::NoEvent;
-                for action in v {
+                for action in *v {
                     custom.update(self.do_action(action, coord, delay));
                 }
                 return custom;
@@ -565,7 +565,7 @@ mod test {
                     tap_hold_interval: 0,
                 }),
             ]],
-            [[Trans, m(&[LCtrl, Enter])]],
+            [[Trans, m(&[LCtrl, Enter].as_slice())]],
         ];
         let mut layout = Layout::new(&LAYERS);
         assert_eq!(CustomEvent::NoEvent, layout.tick());
@@ -742,7 +742,7 @@ mod test {
     #[test]
     fn multiple_actions() {
         static LAYERS: Layers<2, 1, 2> = [
-            [[MultipleActions(&[l(1), k(LShift)]), k(F)]],
+            [[MultipleActions(&[l(1), k(LShift)].as_slice()), k(F)]],
             [[Trans, k(E)]],
         ];
         let mut layout = Layout::new(&LAYERS);


### PR DESCRIPTION
Hi, I noticed that recent commits made the size of Action::HoldTap variant grow in size (tap_hold_interval, HoldTapConfig::Custom). As of [57aa0d3](https://github.com/TeXitoi/keyberon/commit/57aa0d306b60432e2eede2e33ae9a0cacfb70166) the Action type takes 24 bytes (on 32-bit systems). This is due to the size of the `Action::HoldTap` variant (as enums are union types, so the size is determinant + max size of variants), as can be seen here:
![action_now](https://user-images.githubusercontent.com/16623787/180618135-f569c302-7224-4f5e-a72a-8a23ade79071.png)

When combined with the fact that there are `ncols*nrows*nlayers` actions, this can take a considerable amount of space in chip memory. E.g. in my keyboard with `ncols=12, nrows=5, nlayers=5` this results in 7200 bytes.

> Side note: the full size of a layout is the above + `N*1B` for each MultipleKeyCodes + `N*24B` for each MultipleActions + `2*24B` for each HoldTap (2 refs to Action). This might be a bit less if some of the references point to the same object.

In most scenarios users don't use HoldTap too often, so having it embedded in the Action struct is unnecessary. This PR creates a new `HoldTapAction` struct, and uses a reference in the HoldTap variant:
```rust
pub enum Action<T = core::convert::Infallible>
{
    // ...
    HoldTap(&'static HoldTapAction<T>),
    // ...
}
pub struct HoldTapAction<T>
{
    // ...
}
```

This way the HoldTap variant  takes only 4 bytes, reducing the overall size of Action to 12 bytes, which allows to reduce the size of layout by up to 50% (when no HoldTap variants are used). In case of my layout with 5 layers and 9 HoldTaps I was able to go down from 7200 B to 3960 B (reduction by 47.5%). 

This is how the sizes look when using a reference:
![action_after](https://user-images.githubusercontent.com/16623787/180618757-2be0c83f-c314-4fc1-9a5d-45be0a8da818.png)
![hold_tap_after](https://user-images.githubusercontent.com/16623787/180618761-dd981365-5658-46f7-84fb-6158d7a0b3a6.png)