### PR TITLE
[RFC] Support both Layers as const-array and as slices

### DIFF
--- a/src/chording.rs
+++ b/src/chording.rs
@@ -29,7 +29,7 @@
 /// // A count of 30 (ms) is a good default
 /// const DEBOUNCE_COUNT: u16 = 30;
 ///
-/// pub static LAYERS: keyberon::layout::Layers<3, 1, 1> = keyberon::layout::layout! {
+/// pub static LAYERS: keyberon::layout::LayersArray<3, 1, 1> = keyberon::layout::layout! {
 ///     { [ A B C ] }
 /// };
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,10 @@
 #![no_std]
 #![deny(missing_docs)]
 
+#[cfg(test)]
+#[macro_use]
+extern crate alloc;
+
 use usb_device::bus::UsbBusAllocator;
 use usb_device::prelude::*;
 


### PR DESCRIPTION
This is a quick proof-of-concept of a potential solution to https://github.com/TeXitoi/keyberon/issues/88.

Instead of having Layers as concrete type, it is a trait and is auto-implemented for both `&'a [&'a [&'a [Action<T>]]]` and `[[[Action<T>; C]; R]; L]`. This way it is possible to limit the number of type parameters passed. So one could use something like:
```rust
pub struct Keyboard<L: keyberon::layout::Layers + 'static> {
    layout: keyberon::layout::Layout<L>,
}
```
or if the `CustomAction` associated type has to limited (because e.g. we are adding handling of our actions):
```rust
pub struct Keyboard<L: keyberon::layout::Layers<CustomAction = MyAction> + 'static> {
    layout: keyberon::layout::Layout<L>,
}
```

The syntax for defining layers stays quite simple, either `static LAYERS: LayersArray<2, 1, 2> = [...]` or `static LAYERS: LayersSlice = &[...]` (but it's probably better to use the first one). We could even have some different aliases, like e.g.
```rust
pub type LayersXXX<const C: usize, const R: usize, T = core::convert::Infallible> = &'a [[[Action<T>; C]; R];
```
which would be more convenient for users. 

From my initial tests the binary size does not increase, so it seems like everything gets optimized out properly, but I didn't do any strict testing, just running `cargo size --release`.

This was just a quick idea, it's open for discussion and would require code cleanup and renaming a few things.
@riskable Please check if this approach would actually help to simplify your interface.