### PR TITLE
Add optional support for embedded-hal 1.0 (alpha)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ categories = ["embedded", "no-std"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+eh1 = ["dep:embedded-hal-1"]
+
 [dependencies]
 keyberon-macros = { version = "0.1.0", path = "./keyberon-macros" }
 either = { version = "1.6", default-features = false }
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "=1.0.0-alpha.10", optional = true }
 usb-device = "0.2"
 heapless = "0.7"
 arraydeque = { version = "0.4.5", default-features = false }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,6 +1,9 @@
 //! Hardware pin switch matrix handling.
 
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+#[cfg(feature = "eh1")]
+use embedded_hal_1::digital::{InputPin, OutputPin};
+#[cfg(not(feature = "eh1"))]
+use embedded_hal_02::digital::v2::{InputPin, OutputPin};
 
 /// Describes the hardware-level matrix of switches.
 ///


### PR DESCRIPTION
This PR adds support for HALs that implement the alpha release of embedded-hal 1.0.
When embedded-hal 1.0 releases, it can be made the default with embedded-hal 0.2 being optional.