### PR TITLE
Action/Layout: Explicit the Debug trait to be able to use it

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -138,8 +138,8 @@ impl Eq for HoldTapConfig {}
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct HoldTapAction<T, K>
 where
-    T: 'static,
-    K: 'static,
+    T: 'static + Debug,
+    K: 'static + Debug,
 {
     /// The duration, in ticks (usually milliseconds) giving the
     /// difference between a hold and a tap.
@@ -173,8 +173,8 @@ where
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Action<T = core::convert::Infallible, K = KeyCode>
 where
-    T: 'static,
-    K: 'static,
+    T: 'static + Debug,
+    K: 'static + Debug,
 {
     /// No operation action: just do nothing.
     NoOp,
@@ -205,7 +205,7 @@ where
     /// manage with key events.
     Custom(T),
 }
-impl<T, K: Clone> Action<T, K> {
+impl<T: Debug, K: Clone + Debug> Action<T, K> {
     /// Gets the layer number if the action is the `Layer` action.
     pub fn layer(self) -> Option<usize> {
         match self {
@@ -225,25 +225,41 @@ impl<T, K: Clone> Action<T, K> {
 
 /// A shortcut to create a `Action::KeyCode`, useful to create compact
 /// layout.
-pub const fn k<T, K>(kc: K) -> Action<T, K> {
+pub const fn k<T, K>(kc: K) -> Action<T, K>
+where
+    T: Debug,
+    K: Debug,
+{
     Action::KeyCode(kc)
 }
 
 /// A shortcut to create a `Action::Layer`, useful to create compact
 /// layout.
-pub const fn l<T, K>(layer: usize) -> Action<T, K> {
+pub const fn l<T, K>(layer: usize) -> Action<T, K>
+where
+    T: Debug,
+    K: Debug,
+{
     Action::Layer(layer)
 }
 
 /// A shortcut to create a `Action::DefaultLayer`, useful to create compact
 /// layout.
-pub const fn d<T, K>(layer: usize) -> Action<T, K> {
+pub const fn d<T, K>(layer: usize) -> Action<T, K>
+where
+    T: Debug,
+    K: Debug,
+{
     Action::DefaultLayer(layer)
 }
 
 /// A shortcut to create a `Action::MultipleKeyCodes`, useful to
 /// create compact layout.
-pub const fn m<T, K>(kcs: &'static &'static [K]) -> Action<T, K> {
+pub const fn m<T, K>(kcs: &'static &'static [K]) -> Action<T, K>
+where
+    T: Debug,
+    K: Debug,
+{
     Action::MultipleKeyCodes(kcs)
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -49,6 +49,7 @@ pub use keyberon_macros::*;
 use crate::action::{Action, HoldTapAction, HoldTapConfig};
 use crate::key_code::KeyCode;
 use arraydeque::ArrayDeque;
+use core::fmt::Debug;
 use heapless::Vec;
 
 use State::*;
@@ -82,8 +83,8 @@ pub struct Layout<
     T = core::convert::Infallible,
     K = KeyCode,
 > where
-    T: 'static,
-    K: 'static + Copy,
+    T: 'static + Debug,
+    K: 'static + Copy + Debug,
 {
     layers: &'static [[[Action<T, K>; C]; R]; L],
     default_layer: usize,
@@ -219,7 +220,7 @@ impl<T: 'static, K: 'static + Copy> State<T, K> {
 }
 
 #[derive(Debug)]
-struct WaitingState<T: 'static, K: 'static> {
+struct WaitingState<T: 'static + Debug, K: 'static + Debug> {
     coord: (u8, u8),
     timeout: u16,
     delay: u16,
@@ -239,7 +240,11 @@ pub enum WaitingAction {
     NoOp,
 }
 
-impl<T, K> WaitingState<T, K> {
+impl<T, K> WaitingState<T, K>
+where
+    T: 'static + Debug,
+    K: 'static + Debug,
+{
     fn tick(&mut self, stacked: &Stack) -> Option<WaitingAction> {
         self.timeout = self.timeout.saturating_sub(1);
         match self.config {
@@ -335,8 +340,13 @@ impl TapHoldTracker {
     }
 }
 
-impl<const C: usize, const R: usize, const L: usize, T: 'static, K: 'static + Copy>
-    Layout<C, R, L, T, K>
+impl<
+        const C: usize,
+        const R: usize,
+        const L: usize,
+        T: 'static + Debug,
+        K: 'static + Copy + Debug,
+    > Layout<C, R, L, T, K>
 {
     /// Creates a new `Layout` object.
     pub fn new(layers: &'static [[[Action<T, K>; C]; R]; L]) -> Self {


### PR DESCRIPTION
Even though some types derive `Debug`, T/K need to implement it.
```
error[E0277]: `T` doesn't implement `Debug`
   --> src/layout.rs:89:25
    |
89  |     layers: &'static [[[Action<T, K>; C]; R]; L],
    |                         ^^^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
note: required by a bound in `Action`
```