### PR TITLE
debounce: remove into_iter() since n already implements IntoIterator<>

### DIFF
--- a/src/debounce.rs
+++ b/src/debounce.rs
@@ -108,13 +108,14 @@ impl<T: PartialEq> Debouncer<T> {
                     .zip(self.cur.into_iter())
                     .enumerate()
                     .flat_map(move |(i, (o, n))| {
-                        o.into_iter().zip(n.into_iter()).enumerate().filter_map(
-                            move |(j, bools)| match bools {
+                        o.into_iter()
+                            .zip(n)
+                            .enumerate()
+                            .filter_map(move |(j, bools)| match bools {
                                 (false, true) => Some(Event::Press(i as u8, j as u8)),
                                 (true, false) => Some(Event::Release(i as u8, j as u8)),
                                 _ => None,
-                            },
-                        )
+                            })
                     }),
             )
         } else {


### PR DESCRIPTION
Apply clippy suggestion.

I've opened a bug report about the other suggestion:  https://github.com/rust-lang/rust-clippy/issues/11819