### PR TITLE
debounce: remove into_iter() since &self.cur already implements IntoI…

### DIFF
--- a/src/debounce.rs
+++ b/src/debounce.rs
@@ -105,7 +105,7 @@ impl<T: PartialEq> Debouncer<T> {
             Left(
                 self.new
                     .into_iter()
-                    .zip(self.cur.into_iter())
+                    .zip(&self.cur)
                     .enumerate()
                     .flat_map(move |(i, (o, n))| {
                         o.into_iter()


### PR DESCRIPTION
…terator<>

Same as #127 but I missed it yesterday evening. Sorry.