### PR TITLE
Migrate to embedded-hal-1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 keyberon-macros = { version = "0.1.0", path = "./keyberon-macros" }
 either = { version = "1.6", default-features = false }
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "1.0" }
 usb-device = "0.2"
 heapless = "0.7"
 arraydeque = { version = "0.4.5", default-features = false }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,6 +1,6 @@
 //! Hardware pin switch matrix handling.
 
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::digital::{InputPin, OutputPin};
 
 /// Describes the hardware-level matrix of switches.
 ///
@@ -65,7 +65,7 @@ where
         for (ri, row) in self.rows.iter_mut().enumerate() {
             row.set_low()?;
             delay();
-            for (ci, col) in self.cols.iter().enumerate() {
+            for (ci, col) in self.cols.iter_mut().enumerate() {
                 if col.is_low()? {
                     keys[ri][ci] = true;
                 }
@@ -124,7 +124,7 @@ where
         let mut keys = [[false; CS]; RS];
 
         for (ri, row) in self.pins.iter_mut().enumerate() {
-            for (ci, col_option) in row.iter().enumerate() {
+            for (ci, col_option) in row.iter_mut().enumerate() {
                 if let Some(col) = col_option {
                     if col.is_low()? {
                         keys[ri][ci] = true;


### PR DESCRIPTION
 Finally, embedded-hal v1.0 [released](https://blog.rust-embedded.org/embedded-hal-v1/).
 Use v1.0 as a default, and make new feature `embedded-hal-02` for comparability. 