### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ readme = "README.md"
 keyberon-macros = { version = "0.1.0", path = "./keyberon-macros" }
 either = { version = "1.6", default-features = false }
 embedded-hal = { version = "1.0" }
-usb-device = "0.2"
+usb-device = "0.3.2"
 heapless = "0.7"
 arraydeque = { version = "0.4.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 keyberon-macros = { version = "0.1.0", path = "./keyberon-macros" }
 either = { version = "1.6", default-features = false }
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "1.0" }
 usb-device = "0.2"
 heapless = "0.7"
 arraydeque = { version = "0.4.5", default-features = false }

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -120,7 +120,11 @@ impl<B: UsbBus, D: HidDevice> HidClass<'_, B, D> {
         }
     }
 
-    pub fn new_with_polling_interval(device: D, alloc: &UsbBusAllocator<B>, interval: u8) -> HidClass<'_, B, D> {
+    pub fn new_with_polling_interval(
+        device: D,
+        alloc: &UsbBusAllocator<B>,
+        interval: u8,
+    ) -> HidClass<'_, B, D> {
         let max_packet_size = device.max_packet_size();
         HidClass {
             device,
@@ -219,7 +223,7 @@ impl<B: UsbBus, D: HidDevice> UsbClass<B> for HidClass<'_, B, D> {
         Ok(())
     }
 
-    fn get_string(&self, _index: StringIndex, _lang_id: u16) -> Option<&str> {
+    fn get_string(&self, _index: StringIndex, _lang_id: usb_device::LangID) -> Option<&str> {
         None
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,10 @@ where
     B: usb_device::bus::UsbBus,
 {
     UsbDeviceBuilder::new(bus, UsbVidPid(VID, PID))
-        .manufacturer("RIIR Task Force")
-        .product("Keyberon")
-        .serial_number(env!("CARGO_PKG_VERSION"))
+        .strings(&[StringDescriptors::new(LangID::EN)
+            .manufacturer("RIIR Task Force")
+            .product("Keyberon")
+            .serial_number(env!("CARGO_PKG_VERSION"))])
+        .expect("Failed to set strings")
         .build()
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,6 +1,6 @@
 //! Hardware pin switch matrix handling.
 
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::digital::{InputPin, OutputPin};
 
 /// Describes the hardware-level matrix of switches.
 ///
@@ -65,7 +65,7 @@ where
         for (ri, row) in self.rows.iter_mut().enumerate() {
             row.set_low()?;
             delay();
-            for (ci, col) in self.cols.iter().enumerate() {
+            for (ci, col) in self.cols.iter_mut().enumerate() {
                 if col.is_low()? {
                     keys[ri][ci] = true;
                 }
@@ -124,7 +124,7 @@ where
         let mut keys = [[false; CS]; RS];
 
         for (ri, row) in self.pins.iter_mut().enumerate() {
-            for (ci, col_option) in row.iter().enumerate() {
+            for (ci, col_option) in row.iter_mut().enumerate() {
                 if let Some(col) = col_option {
                     if col.is_low()? {
                         keys[ri][ci] = true;


### PR DESCRIPTION
Most tooling has started migrating over to the now stabilised embedded-hal v1.0.0 so it becomes a little tricky to use keyberon without following along with the updates. Fortunately this requires relatively few changes.

Updates;
- embedded-hal
- usb-device