### PR TITLE
Fix holdtap panic

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -270,7 +270,7 @@ impl<T, K> WaitingState<T, K> {
             .iter()
             .find(|s| self.is_corresponding_release(&s.event))
         {
-            if self.timeout >= self.delay - since {
+            if self.timeout + since >= self.delay {
                 Some(WaitingAction::Tap)
             } else {
                 Some(WaitingAction::Hold)

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -750,6 +750,29 @@ mod test {
     }
 
     #[test]
+    fn stacked_hold_tap() {
+        static LAYERS: Layers<2, 1, 1> = [[[
+            k(Enter),
+            HoldTap(&HoldTapAction {
+                timeout: 10,
+                hold: k(LAlt),
+                tap: k(Space),
+                config: HoldTapConfig::Default,
+                tap_hold_interval: 0,
+            }),
+        ]]];
+
+        let mut layout = Layout::new(&LAYERS);
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        // Push 2 events in a row, without ticking:
+        // Press/Release attached to a HoldTap
+        layout.event(Press(0, 1));
+        layout.event(Release(0, 1));
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+        assert_eq!(CustomEvent::NoEvent, layout.tick());
+    }
+
+    #[test]
     fn multiple_actions() {
         static LAYERS: Layers<2, 1, 2> = [
             [[MultipleActions(&[l(1), k(LShift)].as_slice()), k(F)]],


### PR DESCRIPTION
I've been struggling for few months with a "random" panic in my keyboard firmware based on keyberon: see https://github.com/borisfaure/cnano-rs/issues/1 .

This issue occurs when 2 Press/Release events that are linked to an HoldTap action, are received within 2 ticks.
I've added a test that reproduces this issue.

A longer explanation is written in the commit message of the fix.